### PR TITLE
fix: fixed engine service name in catalog

### DIFF
--- a/qip-dev/charts/qip-runtime-catalog/templates/qip-runtime-catalog-deployment.yaml
+++ b/qip-dev/charts/qip-runtime-catalog/templates/qip-runtime-catalog-deployment.yaml
@@ -101,6 +101,8 @@ spec:
                 configMapKeyRef:
                   key: MICRO_DEPLOY_ENABLED
                   name: {{ .Release.Name }}-env
+            - name: ENGINE_SERVICE_NAME
+              value: {{ .Release.Name }}-engine
           image: ghcr.io/netcracker/qubership-integration-runtime-catalog:main
           imagePullPolicy: IfNotPresent
           livenessProbe:


### PR DESCRIPTION
closes https://github.com/Netcracker/qubership-integration-runtime-catalog/issues/380