### PR TITLE
fix: add discriminator for correct selection for type authorizationConfiguration in service call element

### DIFF
--- a/schemas/src/main/resources/qip-model/element/service-call.schema.yaml
+++ b/schemas/src/main/resources/qip-model/element/service-call.schema.yaml
@@ -45,6 +45,8 @@ properties:
           $ref: "#/definitions/ResponseHandler"
       authorizationConfiguration:
         title: Authorization type
+        discriminator:
+          propertyName: type
         oneOf:
           - $ref: "#/definitions/AuthorizationInherit"
           - $ref: "#/definitions/AuthorizationNone"


### PR DESCRIPTION
Add **discriminator** for authorizationConfiguration oneOf schema

Without discriminator, RJSF checks every oneOf variant one by one to find a match. This is a problem for AuthorizationBasic and AuthorizationBearerToken because they look the same at the top level - both have type and data fields. So RJSF pick the first one and cause problem when we try to select AuthorizationBearerToken. That's why discriminator based on type was added. 