### PR TITLE
fix: Fix the moment for setting the default charset value for invoking an HTTP service through the Service Call (#85)

### DIFF
--- a/catalog-library/pom.xml
+++ b/catalog-library/pom.xml
@@ -19,7 +19,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
 
-        <revision>0.1.15</revision>
+        <revision>0.1.14</revision>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring-boot.repackage.skip>true</spring-boot.repackage.skip>

--- a/catalog-library/pom.xml
+++ b/catalog-library/pom.xml
@@ -19,7 +19,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
 
-        <revision>0.1.14</revision>
+        <revision>0.1.15</revision>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring-boot.repackage.skip>true</spring-boot.repackage.skip>

--- a/catalog-library/src/main/resources/elements/service-call/template.hbs
+++ b/catalog-library/src/main/resources/elements/service-call/template.hbs
@@ -127,6 +127,11 @@
     {{/if-property}}
 
     <removeHeader name="CamelHttpQuery"/>
+
+    {{#if-property 'integrationOperationProtocolType' equals='http'}}
+        <process ref="httpProducerCharsetProcessor"/>
+    {{/if-property}}
+
     {{#if-property 'before' presented=''}}
         <step id="Prepare request--{{identifier}}">
             {{#with-property 'before'}}
@@ -250,7 +255,6 @@
 
                 {{#if-property 'integrationOperationProtocolType' equals='http'}}
                     <process ref="httpSenderProcessor"/>
-                    <process ref="httpProducerCharsetProcessor"/>
                     <toD uri="http:stub{{escape (manualQuery
                                                         jsonQueryParameters=(environmentPropertiesJson)
                                                         httpClientConfigurer=(identifier prefix='#'))}}&amp;followRedirects=true" allowOptimisedComponents="false"/>

--- a/designtime-catalog/pom.xml
+++ b/designtime-catalog/pom.xml
@@ -18,8 +18,8 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
 
-        <revision>0.1.14</revision>
-        <catalog-library.revision>0.1.14</catalog-library.revision>
+        <revision>0.1.15</revision>
+        <catalog-library.revision>0.1.15</catalog-library.revision>
 
         <!-- 3rd party dependencies -->
 

--- a/designtime-catalog/pom.xml
+++ b/designtime-catalog/pom.xml
@@ -18,8 +18,8 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
 
-        <revision>0.1.15</revision>
-        <catalog-library.revision>0.1.15</catalog-library.revision>
+        <revision>0.1.14</revision>
+        <catalog-library.revision>0.1.14</catalog-library.revision>
 
         <!-- 3rd party dependencies -->
 

--- a/runtime-catalog/pom.xml
+++ b/runtime-catalog/pom.xml
@@ -17,8 +17,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <revision>0.1.14</revision>
-        <catalog-library.revision>0.1.14</catalog-library.revision>
+        <revision>0.1.15</revision>
+        <catalog-library.revision>0.1.15</catalog-library.revision>
 
         <!-- BOMs -->
 

--- a/runtime-catalog/pom.xml
+++ b/runtime-catalog/pom.xml
@@ -17,8 +17,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <revision>0.1.15</revision>
-        <catalog-library.revision>0.1.15</catalog-library.revision>
+        <revision>0.1.14</revision>
+        <catalog-library.revision>0.1.14</catalog-library.revision>
 
         <!-- BOMs -->
 

--- a/runtime-catalog/src/test/resources/testData/output/builder/templates/service_call_http.xml
+++ b/runtime-catalog/src/test/resources/testData/output/builder/templates/service_call_http.xml
@@ -20,6 +20,7 @@
             <simple>/RestNotify_1</simple>
         </setProperty>
         <removeHeader name="CamelHttpQuery"/>
+        <process ref="httpProducerCharsetProcessor"/>
         <step id="Prepare request--8ff3584f-3666-4c75-ba40-a3c8955c44e8">
             <setProperty name="internalProperty_mappingConfig">
                 <constant><![CDATA[{"name":"UI.52e2590335614b15bf37bd838a08fa97","jsonType":"io.atlasmap.v2.AtlasMapping","mappings":{"mapping":[{"id":"mapping.896a1113ac094c26b67943cb90d59b0a","jsonType":"io.atlasmap.v2.Mapping","inputField":[{"name":"testInputRequestBody","path":"/testInputRequestBody","docId":"source","index":0,"jsonType":"io.atlasmap.json.v2.JsonField","fieldType":"STRING","userCreated":false}],"mappingType":"MAP","outputField":[{"name":"testOutputRequestBody","path":"/testOutputRequestBody","docId":"target","index":0,"jsonType":"io.atlasmap.json.v2.JsonField","fieldType":"STRING","userCreated":false}]}]},"constants":{"constant":[]},"dataSource":[{"id":"source","uri":"atlas:json:source","jsonType":"io.atlasmap.json.v2.JsonDataSource","dataSourceType":"SOURCE"},{"id":"target","uri":"atlas:json:target","jsonType":"io.atlasmap.json.v2.JsonDataSource","dataSourceType":"TARGET"}],"properties":{"property":[]},"lookupTables":{"lookupTable":[]}}]]></constant>
@@ -61,7 +62,6 @@
                 </setProperty>
                 <doTry id="Request--8ff3584f-3666-4c75-ba40-a3c8955c44e8">
                     <process ref="httpSenderProcessor"/>
-                    <process ref="httpProducerCharsetProcessor"/>
                     <toD allowOptimisedComponents="false" uri="http:stub?httpClientConfigurer=#8ff3584f-3666-4c75-ba40-a3c8955c44e8&amp;followRedirects=true"/>
                     <removeProperty name ="internalProperty_enableAuthRestore"/>
                     <process ref="correlationIdReceiverProcessor"/>
@@ -79,7 +79,7 @@
                                 <choice>
                                     <when>
                                         <simple>${exchangeProperty[internalProperty_serviceCall_8ff3584f-3666-4c75-ba40-a3c8955c44e8_Iterator]} == 1</simple>
-                                        <process ref="setCaughtHttpExceptionContextProcessor"/>     
+                                        <process ref="setCaughtHttpExceptionContextProcessor"/>
                                     </when>
                                 </choice>
                             </when>
@@ -125,7 +125,7 @@
                         <choice>
                             <when>
                                 <simple>${exchangeProperty[internalProperty_serviceCall_8ff3584f-3666-4c75-ba40-a3c8955c44e8_Retry]} != true</simple>
-                                <removeProperty name="internalProperty_overrideContextParams"/> 
+                                <removeProperty name="internalProperty_overrideContextParams"/>
                                 <removeProperty name="internalProperty_retryAwait"/>
                                 <process ref="contextRestoreProcessor"/>
                             </when>
@@ -138,7 +138,7 @@
         <choice>
             <when>
                 <simple>${headers.CamelHttpResponseCode} == '200'</simple>
-                <step id="Handle response--8ff3584f-3666-4c75-ba40-a3c8955c44e8">       
+                <step id="Handle response--8ff3584f-3666-4c75-ba40-a3c8955c44e8">
                     <script>
                         <groovy>exchange.setProperty("responseBody", exchange.getMessage().getBody(String.class))</groovy>
                     </script>
@@ -151,7 +151,7 @@
                 </step>
             </when>
             <when>
-                <simple>${headers.CamelHttpResponseCode} range '400..599'</simple>      
+                <simple>${headers.CamelHttpResponseCode} range '400..599'</simple>
                 <process ref="throwCaughtExceptionProcessor"/>
             </when>
         </choice>


### PR DESCRIPTION
## Problem description
Impossible to avoid charset value appearence in Content-Type header in the Service Call execution for invoking the HTTP service

## Solution description
Replace the HttpProducerCharsetProcessor at the beginning of the Service Call execution for invoking the HTTP service

## Remark
After the fix it becomes possible to add code to remove the *CamelCharsetName* property in exchange, like the following
```
exchange.removeProperty("CamelCharsetName")
```
before your code there you specify a new value for the *Content-Type* header using the following code
```
exchange.getMessage().setHeader("Content-Type", "application/vnd.adobe.xdm+json; schema=\"https://ns.adobe.com/experience/offer-management/decision-request;version=1.0\"")
```
to solve the issue.