### PR TITLE
fix: Fix the moment for setting the default charset value for invoking an HTTP service through the Service Call (#85)

### DIFF
--- a/runtime-catalog/src/main/resources/elements/service-call/template.hbs
+++ b/runtime-catalog/src/main/resources/elements/service-call/template.hbs
@@ -138,6 +138,11 @@
     {{/if-property}}
 
     <removeHeader name="CamelHttpQuery"/>
+
+    {{#if-property 'integrationOperationProtocolType' equals='http'}}
+        <process ref="httpProducerCharsetProcessor"/>
+    {{/if-property}}
+
     {{#if-property 'before' presented=''}}
         <step id="Prepare request--{{identifier}}">
             {{#with-property 'before'}}
@@ -262,7 +267,6 @@
                 {{#if-property 'integrationOperationProtocolType' equals='http'}}
                     <process ref="queryParameterFilterProcessor"/>
                     <process ref="httpSenderProcessor"/>
-                    <process ref="httpProducerCharsetProcessor"/>
                     <toD uri="http:stub{{escape (manualQuery
                                                         jsonQueryParameters=(environmentPropertiesJson)
                                                         httpClientConfigurer=(identifier prefix='#'))}}&amp;followRedirects=true" allowOptimisedComponents="false"/>

--- a/runtime-catalog/src/test/resources/testData/output/builder/templates/service_call_http.xml
+++ b/runtime-catalog/src/test/resources/testData/output/builder/templates/service_call_http.xml
@@ -23,6 +23,7 @@
             <simple>false</simple>
         </setProperty>
         <removeHeader name="CamelHttpQuery"/>
+        <process ref="httpProducerCharsetProcessor"/>
         <step id="Prepare request--8ff3584f-3666-4c75-ba40-a3c8955c44e8">
             <setProperty name="internalProperty_mappingConfig">
                 <constant><![CDATA[{"name":"UI.52e2590335614b15bf37bd838a08fa97","jsonType":"io.atlasmap.v2.AtlasMapping","mappings":{"mapping":[{"id":"mapping.896a1113ac094c26b67943cb90d59b0a","jsonType":"io.atlasmap.v2.Mapping","inputField":[{"name":"testInputRequestBody","path":"/testInputRequestBody","docId":"source","index":0,"jsonType":"io.atlasmap.json.v2.JsonField","fieldType":"STRING","userCreated":false}],"mappingType":"MAP","outputField":[{"name":"testOutputRequestBody","path":"/testOutputRequestBody","docId":"target","index":0,"jsonType":"io.atlasmap.json.v2.JsonField","fieldType":"STRING","userCreated":false}]}]},"constants":{"constant":[]},"dataSource":[{"id":"source","uri":"atlas:json:source","jsonType":"io.atlasmap.json.v2.JsonDataSource","dataSourceType":"SOURCE"},{"id":"target","uri":"atlas:json:target","jsonType":"io.atlasmap.json.v2.JsonDataSource","dataSourceType":"TARGET"}],"properties":{"property":[]},"lookupTables":{"lookupTable":[]}}]]></constant>
@@ -65,7 +66,6 @@
                 <doTry id="Request--8ff3584f-3666-4c75-ba40-a3c8955c44e8">
                     <process ref="queryParameterFilterProcessor"/>
                     <process ref="httpSenderProcessor"/>
-                    <process ref="httpProducerCharsetProcessor"/>
                     <toD allowOptimisedComponents="false" uri="http:stub?httpClientConfigurer=#8ff3584f-3666-4c75-ba40-a3c8955c44e8&amp;followRedirects=true"/>
                     <removeProperty name ="internalProperty_enableAuthRestore"/>
                     <process ref="correlationIdReceiverProcessor"/>


### PR DESCRIPTION
## Problem description
Impossible to avoid charset value appearence in Content-Type header in the Service Call execution for invoking the HTTP service

## Solution description
Replace the HttpProducerCharsetProcessor at the beginning of the Service Call execution for invoking the HTTP service

## Remark
After the fix it becomes possible to add code to remove the *CamelCharsetName* property in exchange, like the following
```
exchange.removeProperty("CamelCharsetName")
```
before your code there you specify a new value for the *Content-Type* header using the following code
```
exchange.getMessage().setHeader("Content-Type", "application/vnd.adobe.xdm+json; schema=\"https://ns.adobe.com/experience/offer-management/decision-request;version=1.0\"")
```
to solve the issue.