### PR TITLE
fix: root array fix in mapper

### DIFF
--- a/ui/src/components/mapper/MappingGraphView.tsx
+++ b/ui/src/components/mapper/MappingGraphView.tsx
@@ -15,6 +15,7 @@ import {
   MappingAction,
   MappingDescription,
   SchemaKind,
+  TypeDefinition,
 } from "../../mapper/model/model.ts";
 import {
   Dropdown,
@@ -142,6 +143,24 @@ function buildArcherElementId(
         : `${schemaKind}-${item.id}`;
 }
 
+type DataTypeLabelProps = {
+  type: DataType | null | undefined;
+  typeDefinitions?: TypeDefinition[];
+};
+
+const DataTypeLabel: React.FC<DataTypeLabelProps> = ({
+  type,
+  typeDefinitions = [],
+}) => (
+  <Flex className={graphViewStyles["attribute-type"]}>
+    <span className={graphViewStyles["type-bracket"]}>[</span>
+    <span className={graphViewStyles["type-name"]}>
+      {type ? DataTypes.buildTypeName(type, typeDefinitions) : []}
+    </span>
+    <span className={graphViewStyles["type-bracket"]}>]</span>
+  </Flex>
+);
+
 type SchemaTreeItemViewProps = {
   mappingDescription: MappingDescription;
   schemaKind: SchemaKind;
@@ -225,34 +244,37 @@ const SchemaTreeItemView: React.FC<SchemaTreeItemViewProps> = ({
 }) => {
   const groupLabelClass = (styles["group-label"] as string | undefined) ?? "";
   return isBodyGroup(item) ? (
-    <Space>
-      <span className={groupLabelClass}>body</span>
-      {mappingDescription[schemaKind].body ? (
-        <Select<string>
-          size={"small"}
-          value={getBodyFormat(mappingDescription, schemaKind)}
-          variant="borderless"
-          options={[
-            { value: SourceFormat.JSON, label: "JSON" },
-            { value: SourceFormat.XML, label: "XML" },
-          ]}
-          onChange={(value) => {
-            const body = mappingDescription[schemaKind].body;
-            if (!body) {
-              return;
-            }
-            const type = MetadataUtil.setValue<typeof body, string>(
-              body,
-              METADATA_DATA_FORMAT_KEY,
-              value,
-            ) as DataType;
-            onBodyFormatChange?.(type);
-          }}
-        />
-      ) : (
-        <></>
+    <Flex vertical={false} justify="space-between" align="center" gap={8}>
+      <Space>
+        <span className={groupLabelClass}>body</span>
+        {mappingDescription[schemaKind].body && (
+          <Select<string>
+            size={"small"}
+            value={getBodyFormat(mappingDescription, schemaKind)}
+            variant="borderless"
+            options={[
+              { value: SourceFormat.JSON, label: "JSON" },
+              { value: SourceFormat.XML, label: "XML" },
+            ]}
+            onChange={(value) => {
+              const body = mappingDescription[schemaKind].body;
+              if (!body) {
+                return;
+              }
+              const type = MetadataUtil.setValue<typeof body, string>(
+                body,
+                METADATA_DATA_FORMAT_KEY,
+                value,
+              ) as DataType;
+              onBodyFormatChange?.(type);
+            }}
+          />
+        )}
+      </Space>
+      {DataTypes.isArrayType(item.type) && (
+        <DataTypeLabel type={mappingDescription[schemaKind].body} />
       )}
-    </Space>
+    </Flex>
   ) : isConstantGroup(item) ? (
     <span className={groupLabelClass}>constants</span>
   ) : isHeaderGroup(item) ? (
@@ -273,15 +295,10 @@ const SchemaTreeItemView: React.FC<SchemaTreeItemViewProps> = ({
           <></>
         )}
       </Space>
-      <Flex className={graphViewStyles["attribute-type"]}>
-        <span className={graphViewStyles["type-bracket"]}>[</span>
-        <span className={graphViewStyles["type-name"]}>
-          {item.attribute.type
-            ? DataTypes.buildTypeName(item.attribute.type, item.typeDefinitions)
-            : []}
-        </span>
-        <span className={graphViewStyles["type-bracket"]}>]</span>
-      </Flex>
+      <DataTypeLabel
+        type={item.attribute.type}
+        typeDefinitions={item.typeDefinitions}
+      />
     </Flex>
   ) : isConstantItem(item) ? (
     <>

--- a/ui/src/components/mapper/transformation/parameters/ExpressionEditor.tsx
+++ b/ui/src/components/mapper/transformation/parameters/ExpressionEditor.tsx
@@ -22,7 +22,10 @@ import {
   Uri,
   IMarkdownString,
 } from "monaco-editor";
-import { Constant } from "../../../../mapper/model/model.ts";
+import {
+  Constant,
+  MessageSchema,
+} from "../../../../mapper/model/model.ts";
 import { validateExpression } from "../../../../mapper/expressions/validation.ts";
 import { MappingUtil } from "../../../../mapper/util/mapping.ts";
 import { AttributeDetail } from "../../../../mapper/util/schema.ts";
@@ -112,6 +115,7 @@ const MAPPER_TRANSFORMATION_EXPRESSION_LANGUAGE_TOKENIZER: languages.IMonarchLan
 type ExpressionReferences = {
   attributes: AttributeDetail[];
   constants: Constant[];
+  sourceSchema?: MessageSchema;
 };
 
 class TransformationExpressionCompletionProvider
@@ -610,6 +614,7 @@ mergeObjects(
     const references = this.getReferenceMap().get(model.uri.toString()) ?? {
       attributes: [],
       constants: [],
+      sourceSchema: undefined,
     };
     const line = model.getLineContent(position.lineNumber);
     const textBeforePosition = line.substring(0, position.column);
@@ -645,13 +650,19 @@ mergeObjects(
         range,
       })),
       ...references.attributes
-        .filter((detail) => detail.kind && detail.path.every((a) => a.name))
-        .map((detail) => ({
-          label: detail.kind + "." + detail.path.map((a) => a.name).join("."),
-          kind: languages.CompletionItemKind.Variable,
-          insertText: buildAttributeReferenceText(detail),
-          range,
-        })),
+        .filter((detail) => detail.kind)
+        .map((detail) => {
+          const referenceText = buildAttributeReferenceText(
+            detail,
+            references.sourceSchema,
+          );
+          return {
+            label: referenceText,
+            kind: languages.CompletionItemKind.Variable,
+            insertText: referenceText,
+            range,
+          };
+        }),
       ...references.constants
         .filter((constant) => constant.name)
         .map((constant) => ({
@@ -754,7 +765,11 @@ export const ExpressionEditor: React.FC<ExpressionEditorProps> = ({
         MappingUtil.findConstantById(mappingDescription, source.constantId),
       )
       .filter((constant) => !!constant);
-    setReferences({ attributes, constants });
+    setReferences({
+      attributes,
+      constants,
+      sourceSchema: mappingDescription.source,
+    });
   }, [mappingDescription, action]);
 
   const validateValue = useCallback(
@@ -782,6 +797,7 @@ export const ExpressionEditor: React.FC<ExpressionEditorProps> = ({
             endColumn: location.end.column,
           });
         },
+        mappingDescription.source,
       );
 
       monacoRef.current?.editor?.setModelMarkers(
@@ -790,7 +806,7 @@ export const ExpressionEditor: React.FC<ExpressionEditorProps> = ({
         markers,
       );
     },
-    [references.attributes, references.constants],
+    [references.attributes, references.constants, mappingDescription.source],
   );
 
   const monacoTheme = useMonacoTheme();

--- a/ui/src/mapper/expressions/references.ts
+++ b/ui/src/mapper/expressions/references.ts
@@ -1,8 +1,16 @@
 import { ExpressionNode, OperationNode, ReferenceNode } from "./model.ts";
-import { Constant } from "../model/model.ts";
-import { AttributeDetail } from "../util/schema.ts";
+import {
+  Attribute,
+  AttributeKind,
+  Constant,
+  MessageSchema,
+} from "../model/model.ts";
+import { AttributeDetail, isBodyRootArray } from "../util/schema.ts";
+import { MappingActions } from "../actions-text/util.ts";
 
 export type ReferenceProcessCallback = (node: ReferenceNode) => void;
+
+const EXPRESSION_PATH_ESCAPE_CHARS = " .\t\r\n\\+-*!><,=%()|&/";
 
 export function processReferences(
   expression: ExpressionNode,
@@ -20,9 +28,8 @@ export function processReferences(
 }
 
 export function escape(value: string): string {
-  const charactersToEscape = " .\t\r\n\\+-*!><,=%()|&/";
   return [...value]
-    .map((i) => (charactersToEscape.indexOf(i) >= 0 ? `\\${i}` : i))
+    .map((i) => (EXPRESSION_PATH_ESCAPE_CHARS.indexOf(i) >= 0 ? `\\${i}` : i))
     .join("");
 }
 
@@ -30,8 +37,25 @@ export function buildConstantReferenceText(constant: Constant): string {
   return `constant.${escape(constant.name)}`;
 }
 
-export function buildAttributeReferenceText(detail: AttributeDetail): string {
-  return [detail.kind, ...detail.path.map((a) => a.name)]
-    .map((i) => escape(i))
+export function getExpressionPathNames(
+  kind: AttributeKind,
+  path: Attribute[],
+  sourceSchema?: MessageSchema,
+): string[] {
+  const segments = path.map((attribute) => attribute.name ?? "");
+  if (kind === "body" && isBodyRootArray(sourceSchema)) {
+    return ["", ...segments];
+  }
+  return segments;
+}
+
+export function buildAttributeReferenceText(
+  detail: AttributeDetail,
+  sourceSchema?: MessageSchema,
+): string {
+  return [detail.kind, ...getExpressionPathNames(detail.kind, detail.path, sourceSchema)]
+    .map((segment) =>
+      MappingActions.escapeValue(segment, EXPRESSION_PATH_ESCAPE_CHARS),
+    )
     .join(".");
 }

--- a/ui/src/mapper/expressions/validation.ts
+++ b/ui/src/mapper/expressions/validation.ts
@@ -1,5 +1,5 @@
 import { AttributeDetail } from "../util/schema.ts";
-import { Constant } from "../model/model.ts";
+import { Constant, MessageSchema } from "../model/model.ts";
 import { parse } from "./parser.ts";
 import { LocationRange } from "pegjs";
 import {
@@ -8,7 +8,7 @@ import {
   ReferenceNode,
 } from "./model.ts";
 import { MappingActions } from "../actions-text/util.ts";
-import { processReferences } from "./references.ts";
+import { getExpressionPathNames, processReferences } from "./references.ts";
 import { isParseError } from "../actions-text/parser.ts";
 
 export type TransformationValidationCallback = (
@@ -16,10 +16,28 @@ export type TransformationValidationCallback = (
   message: string,
 ) => void;
 
+function pathsMatch(
+  attribute: AttributeDetail,
+  expressionPath: string[],
+  sourceSchema?: MessageSchema,
+): boolean {
+  const expected = getExpressionPathNames(
+    attribute.kind,
+    attribute.path,
+    sourceSchema,
+  );
+  const normalized = expressionPath.map((s) => (s === "_" ? "" : s));
+  return (
+    expected.length === normalized.length &&
+    expected.every((name, i) => name === normalized[i])
+  );
+}
+
 export function referenceIsValid(
   node: ReferenceNode,
   attributes: AttributeDetail[],
   constants: Constant[],
+  sourceSchema?: MessageSchema,
 ): boolean {
   return node.kind === "constant"
     ? constants.some(
@@ -28,10 +46,10 @@ export function referenceIsValid(
     : attributes.some(
         (attribute) =>
           attribute.kind === node.kind &&
-          attribute.path.length ===
-            (node as AttributeReferenceNode).path.length &&
-          attribute.path.every(
-            (a, i) => a.name === (node as AttributeReferenceNode).path[i],
+          pathsMatch(
+            attribute,
+            (node as AttributeReferenceNode).path,
+            sourceSchema,
           ),
       );
 }
@@ -41,8 +59,9 @@ export function validateReference(
   attributes: AttributeDetail[],
   constants: Constant[],
   callback: TransformationValidationCallback,
+  sourceSchema?: MessageSchema,
 ) {
-  if (!referenceIsValid(node, attributes, constants)) {
+  if (!referenceIsValid(node, attributes, constants, sourceSchema)) {
     const message = `Unknown ${node.kind === "body" ? "attribute" : node.kind}: ${MappingActions.escapePath(
       node.kind === "constant"
         ? [(node as ConstantReferenceNode).name]
@@ -57,11 +76,18 @@ export function validateExpression(
   attributes: AttributeDetail[],
   constants: Constant[],
   callback: TransformationValidationCallback,
+  sourceSchema?: MessageSchema,
 ): void {
   try {
     const expression = parse(text);
     processReferences(expression, (node) =>
-      validateReference(node, attributes, constants, callback),
+      validateReference(
+        node,
+        attributes,
+        constants,
+        callback,
+        sourceSchema,
+      ),
     );
   } catch (exception) {
     if (isParseError(exception)) {

--- a/ui/src/mapper/util/schema.ts
+++ b/ui/src/mapper/util/schema.ts
@@ -42,6 +42,14 @@ export function isAttributeDetail(obj: unknown): obj is AttributeDetail {
   );
 }
 
+export function isBodyRootArray(schema?: MessageSchema | null): boolean {
+  if (!schema?.body) {
+    return false;
+  }
+  const resolved = DataTypes.resolveType(schema.body, []);
+  return DataTypes.isArrayType(resolved.type);
+}
+
 export class MessageSchemaUtil {
   public static findAttribute(
     schema: MessageSchema,

--- a/ui/src/mapper/verification/transformations.ts
+++ b/ui/src/mapper/verification/transformations.ts
@@ -42,6 +42,7 @@ export class TransformationExpressionVerifier extends Verifier<TransformationPar
       attributes,
       constants,
       (_location, message) => errors.push({ message }),
+      entity.mapping.source,
     );
     return errors;
   }

--- a/ui/tests/mapper/expressions/references.spec.ts
+++ b/ui/tests/mapper/expressions/references.spec.ts
@@ -1,0 +1,133 @@
+import {
+  buildAttributeReferenceText,
+  buildConstantReferenceText,
+  escape,
+  getExpressionPathNames,
+  processReferences,
+} from "../../../src/mapper/expressions/references.ts";
+import { AttributeDetail } from "../../../src/mapper/util/schema.ts";
+import {
+  Constant,
+  MessageSchema,
+} from "../../../src/mapper/model/model.ts";
+import { ReferenceNode } from "../../../src/mapper/expressions/model.ts";
+import { parse } from "../../../src/mapper/expressions/parser.ts";
+import { DataTypes } from "../../../src/mapper/util/types.ts";
+
+describe("expression references", () => {
+  const arrayRootSourceSchema: MessageSchema = {
+    headers: [],
+    properties: [],
+    body: {
+      name: "array",
+      itemType: {
+        name: "object",
+        schema: {
+          id: "schema1",
+          attributes: [
+            { id: "a1", name: "field", type: { name: "string" } },
+          ],
+        },
+      },
+    },
+  };
+
+  const objectRootSourceSchema: MessageSchema = {
+    headers: [],
+    properties: [],
+    body: {
+      name: "object",
+      schema: {
+        id: "schema1",
+        attributes: [
+          { id: "a1", name: "field", type: { name: "string" } },
+        ],
+      },
+    },
+  };
+
+  const bodyFieldDetail: AttributeDetail = {
+    kind: "body",
+    path: [{ id: "a1", name: "field", type: { name: "string" } }],
+    definitions: [],
+  };
+
+  describe("escape", () => {
+    it("should escape special characters in expression path segments", () => {
+      expect(escape("a b")).toEqual("a\\ b");
+      expect(escape("plain")).toEqual("plain");
+    });
+  });
+
+  describe("buildConstantReferenceText", () => {
+    it("should build a constant reference with escaped name", () => {
+      const constant: Constant = {
+        type: DataTypes.integerType(),
+        id: "c1",
+        name: "my constant",
+        valueSupplier: { kind: "given", value: "x" }
+      };
+      expect(buildConstantReferenceText(constant)).toEqual(
+        "constant.my\\ constant",
+      );
+    });
+  });
+
+  describe("getExpressionPathNames", () => {
+    it("should return attribute names for non-body kinds", () => {
+      expect(
+        getExpressionPathNames(
+          "header",
+          [{ id: "h1", name: "X-Header", type: { name: "string" } }],
+          arrayRootSourceSchema,
+        ),
+      ).toEqual(["X-Header"]);
+    });
+
+    it("should prepend an empty segment when body root is an array", () => {
+      expect(
+        getExpressionPathNames(
+          "body",
+          bodyFieldDetail.path,
+          arrayRootSourceSchema,
+        ),
+      ).toEqual(["", "field"]);
+    });
+
+    it("should not prepend an empty segment when body root is an object", () => {
+      expect(
+        getExpressionPathNames(
+          "body",
+          bodyFieldDetail.path,
+          objectRootSourceSchema,
+        ),
+      ).toEqual(["field"]);
+    });
+  });
+
+  describe("buildAttributeReferenceText", () => {
+    it("should build a body reference with array-root placeholder segment", () => {
+      expect(
+        buildAttributeReferenceText(bodyFieldDetail, arrayRootSourceSchema),
+      ).toEqual("body.\\_.field");
+    });
+
+    it("should build a body reference without placeholder for object root", () => {
+      expect(
+        buildAttributeReferenceText(bodyFieldDetail, objectRootSourceSchema),
+      ).toEqual("body.field");
+    });
+  });
+
+  describe("processReferences", () => {
+    it("should invoke callback for each reference in an expression", () => {
+      const references: ReferenceNode[] = [];
+      processReferences(parse("body.field + constant.foo"), (node) =>
+        references.push(node),
+      );
+      expect(references).toHaveLength(2);
+      expect(references[0].kind).toEqual("body");
+      expect(references[1].kind).toEqual("constant");
+    });
+  });
+});

--- a/ui/tests/mapper/expressions/validation.spec.ts
+++ b/ui/tests/mapper/expressions/validation.spec.ts
@@ -1,0 +1,118 @@
+import {
+  referenceIsValid,
+  validateExpression,
+} from "../../../src/mapper/expressions/validation.ts";
+import { AttributeDetail } from "../../../src/mapper/util/schema.ts";
+import {
+  Constant,
+  MessageSchema,
+} from "../../../src/mapper/model/model.ts";
+import { parse } from "../../../src/mapper/expressions/parser.ts";
+import { processReferences } from "../../../src/mapper/expressions/references.ts";
+import { ReferenceNode } from "../../../src/mapper/expressions/model.ts";
+import { DataTypes } from "../../../src/mapper/util/types.ts";
+
+describe("expression validation", () => {
+  const arrayRootSourceSchema: MessageSchema = {
+    headers: [],
+    properties: [],
+    body: {
+      name: "array",
+      itemType: {
+        name: "object",
+        schema: {
+          id: "schema1",
+          attributes: [
+            { id: "a1", name: "field", type: { name: "string" } },
+          ],
+        },
+      },
+    },
+  };
+
+  const bodyFieldDetail: AttributeDetail = {
+    kind: "body",
+    path: [{ id: "a1", name: "field", type: { name: "string" } }],
+    definitions: [],
+  };
+
+  const constants: Constant[] = [
+    {
+      id: "c1",
+      name: "foo",
+      valueSupplier: { kind: "given", value: "bar" },
+      type: DataTypes.stringType(),
+    },
+  ];
+
+  describe("referenceIsValid", () => {
+    it("should accept body references with array-root placeholder path", () => {
+      const expression = parse("body._.field");
+      const references: ReferenceNode[] = [];
+      processReferences(expression, (node) => references.push(node));
+
+      expect(
+        referenceIsValid(
+          references[0],
+          [bodyFieldDetail],
+          constants,
+          arrayRootSourceSchema,
+        ),
+      ).toBe(true);
+    });
+
+    it("should reject unknown body references", () => {
+      const expression = parse("body._.missing");
+      const references: ReferenceNode[] = [];
+      processReferences(expression, (node) => references.push(node));
+
+      expect(
+        referenceIsValid(
+          references[0],
+          [bodyFieldDetail],
+          constants,
+          arrayRootSourceSchema,
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("validateExpression", () => {
+    it("should not report errors for valid array-root body references", () => {
+      const errors: string[] = [];
+      validateExpression(
+        "body._.field",
+        [bodyFieldDetail],
+        constants,
+        (_location, message) => errors.push(message),
+        arrayRootSourceSchema,
+      );
+      expect(errors).toEqual([]);
+    });
+
+    it("should report errors for unknown references", () => {
+      const errors: string[] = [];
+      validateExpression(
+        "body._.missing",
+        [bodyFieldDetail],
+        constants,
+        (_location, message) => errors.push(message),
+        arrayRootSourceSchema,
+      );
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain("Unknown attribute");
+    });
+
+    it("should report parse errors", () => {
+      const errors: string[] = [];
+      validateExpression(
+        "body +",
+        [bodyFieldDetail],
+        constants,
+        (_location, message) => errors.push(message),
+        arrayRootSourceSchema,
+      );
+      expect(errors.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/ui/tests/mapper/util/schema.spec.ts
+++ b/ui/tests/mapper/util/schema.spec.ts
@@ -1,4 +1,7 @@
-import { MessageSchemaUtil } from "../../../src/mapper/util/schema.ts";
+import {
+  isBodyRootArray,
+  MessageSchemaUtil,
+} from "../../../src/mapper/util/schema.ts";
 import {
   Attribute,
   AttributeReference,
@@ -7,6 +10,39 @@ import {
 } from "../../../src/mapper/model/model.ts";
 
 describe("Mapper", () => {
+  describe("isBodyRootArray", () => {
+    it("should return false when schema or body is missing", () => {
+      expect(isBodyRootArray()).toBe(false);
+      expect(isBodyRootArray(null)).toBe(false);
+    });
+
+    it("should return false when body root is an object", () => {
+      expect(
+        isBodyRootArray({
+          headers: [],
+          properties: [],
+          body: {
+            name: "object",
+            schema: { id: "schema1", attributes: [] },
+          },
+        }),
+      ).toBe(false);
+    });
+
+    it("should return true when body root is an array", () => {
+      expect(
+        isBodyRootArray({
+          headers: [],
+          properties: [],
+          body: {
+            name: "array",
+            itemType: { name: "string" },
+          },
+        }),
+      ).toBe(true);
+    });
+  });
+
   describe("MessageSchemaUtil", () => {
     const messageSchema: MessageSchema = {
       headers: [

--- a/ui/tests/mapper/verification/transformations.spec.ts
+++ b/ui/tests/mapper/verification/transformations.spec.ts
@@ -1,0 +1,96 @@
+import { TransformationExpressionVerifier } from "../../../src/mapper/verification/transformations.ts";
+import { TransformationParameterDetail } from "../../../src/mapper/verification/base.ts";
+import {
+  MappingAction,
+  MappingDescription,
+} from "../../../src/mapper/model/model.ts";
+import { AttributeDetail } from "../../../src/mapper/util/schema.ts";
+import { MappingActions } from "../../../src/mapper/util/actions.ts";
+
+jest.mock("../../../src/mapper/util/actions.ts", () => ({
+  MappingActions: {
+    getSourcesDetail: jest.fn(),
+  },
+}));
+
+describe("TransformationExpressionVerifier", () => {
+  const arrayRootMapping: MappingDescription = {
+    source: {
+      headers: [],
+      properties: [],
+      body: {
+        name: "array",
+        itemType: {
+          name: "object",
+          schema: {
+            id: "schema1",
+            attributes: [
+              { id: "a1", name: "field", type: { name: "string" } },
+            ],
+          },
+        },
+      },
+    },
+    target: {
+      headers: [],
+      properties: [],
+      body: {
+        name: "object",
+        schema: {
+          id: "target-schema",
+          attributes: [],
+        },
+      },
+    },
+    constants: [],
+    actions: [],
+  };
+
+  const bodyFieldSource: AttributeDetail = {
+    kind: "body",
+    path: [{ id: "a1", name: "field", type: { name: "string" } }],
+    definitions: [],
+  };
+
+  const action: MappingAction = {
+    id: "action1",
+    sources: [{ type: "constant", kind: "body", path: ["a1"] }],
+    target: {
+      kind: "body",
+      path: [],
+      type: "constant"},
+    transformation: {
+      name: "expression",
+      parameters: ["body._.field"],
+    },
+  };
+
+  const entity: TransformationParameterDetail = {
+    action,
+    mapping: arrayRootMapping,
+    parameterValue: "body._.field",
+    parameterIndex: 0,
+  };
+
+  beforeEach(() => {
+    jest.mocked(MappingActions.getSourcesDetail).mockReturnValue([
+      bodyFieldSource,
+    ]);
+  });
+
+  it("should validate expressions using the mapping source schema", () => {
+    expect(new TransformationExpressionVerifier().verify(entity)).toEqual([]);
+  });
+
+  it("should return errors for invalid references in expressions", () => {
+
+    const invalidEntity: TransformationParameterDetail = {
+      ...entity,
+      parameterValue: "body._.missing",
+    };
+
+    const errors = new TransformationExpressionVerifier().verify(invalidEntity);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain("Unknown attribute");
+  });
+});


### PR DESCRIPTION
Add:
1. Label for the case when source/target is root array
2. Autocompletion with validation for root array case 

attached screenshots of autocompletion and label for root array case:
<img width="839" height="1034" alt="autocompletion" src="https://github.com/user-attachments/assets/54e51a0f-55e2-4140-b3c7-87d993c49568" />

<img width="1401" height="743" alt="label and correct validation" src="https://github.com/user-attachments/assets/8b273c0b-4231-41ab-b54f-5d323ab7d63c" />

Close #284 

 