### PR TITLE
fix: Ordered element issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist-lib/
 .idea/
 *.iml
 .vscode/
+.aider*
 .DS_Store
 Thumbs.db
 .env

--- a/runtime-catalog/src/main/java/org/qubership/integration/platform/runtime/catalog/service/OrderedElementService.java
+++ b/runtime-catalog/src/main/java/org/qubership/integration/platform/runtime/catalog/service/OrderedElementService.java
@@ -29,7 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
+import java.util.stream.IntStream;
 
 @Service
 @Transactional
@@ -68,36 +68,32 @@ public class OrderedElementService {
         if (!currentPriority.equals(newPriority)) {
             List<ChainElement> sortedElements = orderedElementUtils.getSortedChildren(parentElement);
             int currentPriorityIndex = orderedElementUtils.getCurrentElementIndex(sortedElements);
-            int newPriorityIndex = orderedElementUtils.getIndexByPriority(sortedElements, newPriority);
+
+            boolean hasExactPriorityMatch = sortedElements.stream()
+                    .anyMatch(it -> newPriority.equals(orderedElementUtils.getPriorityAsInt(it)));
+
+            int targetIndex = orderedElementUtils.getIndexToInsert(sortedElements, newPriority);
+
             orderedElementUtils.updatePriority(element, newPriority);
 
-            List<ChainElement> elementsToUpdate;
-            Function<Integer, Integer> priorityFunction;
-            if (newPriority > currentPriority) {
-                if (newPriorityIndex == -1) {
-                    if (currentPriorityIndex + 1 >= sortedElements.size()) {
-                        return chainDiff;
-                    }
-                    newPriorityIndex = sortedElements.stream()
-                            .map(orderedElementUtils::getPriorityAsInt)
-                            .filter(it -> it < sortedElements.size())
-                            .max(Integer::compareTo)
-                            .orElse(currentPriorityIndex);
+            // Only shift other elements if we're moving to a position that already has an element with that priority
+            if (hasExactPriorityMatch) {
+                List<ChainElement> elementsToUpdate = List.of();
+                if (targetIndex > currentPriorityIndex) {
+                    elementsToUpdate = IntStream.rangeClosed(currentPriorityIndex + 1, targetIndex)
+                            .mapToObj(sortedElements::get)
+                            .toList();
+                } else if (targetIndex < currentPriorityIndex) {
+                    elementsToUpdate = IntStream.range(targetIndex, currentPriorityIndex)
+                            .mapToObj(sortedElements::get)
+                            .toList();
                 }
-                elementsToUpdate = sortedElements.subList(currentPriorityIndex + 1, newPriorityIndex + 1);
-                priorityFunction = (priority) -> priority - 1;
-            } else {
-                if (newPriorityIndex == -1) {
-                    return chainDiff;
-                }
-                elementsToUpdate = sortedElements.subList(newPriorityIndex, currentPriorityIndex);
-                priorityFunction = (priority) -> priority + 1;
-            }
 
-            for (ChainElement elementToUpdate : elementsToUpdate) {
-                Integer priority = orderedElementUtils.getPriorityAsInt(elementToUpdate);
-                if (priority < sortedElements.size()) {
-                    orderedElementUtils.updatePriority(elementToUpdate, priorityFunction.apply(priority));
+                for (ChainElement elementToUpdate : elementsToUpdate) {
+                    Integer priority = orderedElementUtils.getPriorityAsInt(elementToUpdate);
+                    orderedElementUtils.updatePriority(elementToUpdate,
+                            targetIndex > currentPriorityIndex ? priority - 1 : priority + 1);
+
                     chainDiff.addUpdatedElement(elementToUpdate);
                 }
             }

--- a/runtime-catalog/src/main/java/org/qubership/integration/platform/runtime/catalog/util/OrderedElementUtils.java
+++ b/runtime-catalog/src/main/java/org/qubership/integration/platform/runtime/catalog/util/OrderedElementUtils.java
@@ -23,6 +23,7 @@ import org.qubership.integration.platform.runtime.catalog.persistence.configs.en
 
 import java.util.List;
 import java.util.Objects;
+import java.util.function.IntPredicate;
 
 public class OrderedElementUtils {
 
@@ -66,12 +67,24 @@ public class OrderedElementUtils {
                 .orElse(-1);
     }
 
-    public Integer getIndexByPriority(List<ChainElement> sortedElements, Integer priority) {
+    private Integer getIndexByPredicate(List<ChainElement> sortedElements, IntPredicate predicate) {
         return sortedElements.stream()
-                .filter(it -> Objects.equals(getPriorityAsInt(it), priority))
+                .filter(it -> predicate.test(getPriorityAsInt(it)))
                 .findFirst()
                 .map(sortedElements::indexOf)
                 .orElse(-1);
+    }
+
+    public Integer getIndexToInsert(List<ChainElement> sortedElements, Integer priority) {
+        Integer targetIndex = getIndexByPredicate(sortedElements,
+                currentPriority -> Objects.equals(currentPriority, priority));
+
+        if (targetIndex == -1) {
+            targetIndex = getIndexByPredicate(sortedElements,
+                    currentPriority -> currentPriority > priority);
+        }
+
+        return targetIndex == -1 ? sortedElements.size() - 1 : targetIndex;
     }
 
     public Integer getPriorityAsInt(ChainElement element) {

--- a/runtime-catalog/src/test/java/org/qubership/integration/platform/runtime/catalog/service/OrderedElementServiceTest.java
+++ b/runtime-catalog/src/test/java/org/qubership/integration/platform/runtime/catalog/service/OrderedElementServiceTest.java
@@ -225,9 +225,26 @@ public class OrderedElementServiceTest {
                         "Move first down to priority 100",
                         FIRST_ELEMENT_ID,
                         100,
+                        Collections.emptyMap()
+                ),
+                Arguments.of(
+                        "Move first down to priority 3",
+                        FIRST_ELEMENT_ID,
+                        3,
+                        Collections.emptyMap()
+                ),
+                Arguments.of(
+                        "Move second down to priority 3",
+                        SECOND_ELEMENT_ID,
+                        3,
+                        Collections.emptyMap()
+                ),
+                Arguments.of(
+                        "Move third down to priority 99",
+                        THIRD_ELEMENT_ID,
+                        99,
                         ImmutableMap.<String, String>builder()
-                                .put(SECOND_ELEMENT_ID, "0")
-                                .put(THIRD_ELEMENT_ID, "1")
+                                .put(FOURTH_ELEMENT_ID, "98")
                                 .build()
                 ),
                 Arguments.of(

--- a/ui/src/hooks/graph/context_menu/usePriorityContextMenuItems.tsx
+++ b/ui/src/hooks/graph/context_menu/usePriorityContextMenuItems.tsx
@@ -55,47 +55,46 @@ export const usePriorityContextMenuItems: ContextMenuItemsHook = ({
       const currentIndex: number = childrenOfTheSameType
         .map((node) => node.id)
         .indexOf(selectedNode.id);
-      const orderedChildrenLength: number = childrenOfTheSameType.filter(
-        (node) =>
-          getPriority(node, priorityProperty) < childrenOfTheSameType.length,
-      ).length;
       const currentPriority: number = getPriority(
         selectedNode,
         priorityProperty,
       );
 
       const items: ContextMenuItem[] = [];
-      if (
-        currentIndex > 0 &&
-        currentPriority > 0 &&
-        currentPriority < orderedChildrenLength
-      ) {
+      if (currentIndex > 0 && currentPriority > 0) {
+        const newPriority = calculateMoveUpPriority(
+          childrenOfTheSameType,
+          currentIndex,
+          priorityProperty,
+        );
         items.push({
           id: uuidv4(),
-          text: "Move up",
+          text: `Move up (New priority: ${newPriority})`,
           handler: () =>
             updateElementPriority(
               chainId!,
               selectedNode,
               priorityProperty,
-              currentPriority - 1,
+              newPriority,
             ),
         });
       }
 
-      if (
-        currentIndex + 1 < childrenOfTheSameType.length &&
-        currentPriority + 1 < orderedChildrenLength
-      ) {
+      if (currentIndex + 1 < childrenOfTheSameType.length) {
+        const newPriority = calculateMoveDownPriority(
+          childrenOfTheSameType,
+          currentIndex,
+          priorityProperty,
+        );
         items.push({
           id: uuidv4(),
-          text: "Move down",
+          text: `Move down (New priority: ${newPriority})`,
           handler: () =>
             updateElementPriority(
               chainId!,
               selectedNode,
               priorityProperty,
-              currentPriority + 1,
+              newPriority,
             ),
         });
       }
@@ -104,6 +103,24 @@ export const usePriorityContextMenuItems: ContextMenuItemsHook = ({
     }
 
     return [];
+  };
+
+  const calculateMoveUpPriority = (
+    elements: Node<ChainGraphNodeData>[],
+    currentIndex: number,
+    priorityProperty: string,
+  ): number => {
+    const prevElement = elements[currentIndex - 1];
+    return getPriority(prevElement, priorityProperty);
+  };
+
+  const calculateMoveDownPriority = (
+    elements: Node<ChainGraphNodeData>[],
+    currentIndex: number,
+    priorityProperty: string,
+  ): number => {
+    const nextElement = elements[currentIndex + 1];
+    return getPriority(nextElement, priorityProperty);
   };
 
   const updateElementPriority = async (

--- a/ui/tests/hooks/graph/context_menu/usePriorityContextMenuItems.test.tsx
+++ b/ui/tests/hooks/graph/context_menu/usePriorityContextMenuItems.test.tsx
@@ -189,7 +189,7 @@ describe("usePriorityContextMenuItems", () => {
       const contextMenuItems = result.current.buildItems([nodes[0]]);
 
       expect(contextMenuItems).toHaveLength(1);
-      expect(contextMenuItems[0].text).toBe("Move up");
+      expect(contextMenuItems[0].text).toBe("Move up (New priority: 0)");
     });
 
     it("should return move down item when element can be moved down", () => {
@@ -222,7 +222,7 @@ describe("usePriorityContextMenuItems", () => {
       const contextMenuItems = result.current.buildItems([nodes[0]]);
 
       expect(contextMenuItems).toHaveLength(1);
-      expect(contextMenuItems[0].text).toBe("Move down");
+      expect(contextMenuItems[0].text).toBe("Move down (New priority: 1)");
     });
 
     it("should return both move up and move down items when element is in the middle", () => {
@@ -256,8 +256,8 @@ describe("usePriorityContextMenuItems", () => {
       const contextMenuItems = result.current.buildItems([nodes[1]]);
 
       expect(contextMenuItems).toHaveLength(2);
-      expect(contextMenuItems[0].text).toBe("Move up");
-      expect(contextMenuItems[1].text).toBe("Move down");
+      expect(contextMenuItems[0].text).toBe("Move up (New priority: 0)");
+      expect(contextMenuItems[1].text).toBe("Move down (New priority: 2)");
     });
 
     it("should not show move up item when element is at the top", () => {
@@ -290,7 +290,7 @@ describe("usePriorityContextMenuItems", () => {
       const contextMenuItems = result.current.buildItems([nodes[0]]);
 
       expect(contextMenuItems).toHaveLength(1);
-      expect(contextMenuItems[0].text).toBe("Move down");
+      expect(contextMenuItems[0].text).toBe("Move down (New priority: 1)");
     });
 
     it("should not show move down item when element is at the bottom", () => {
@@ -323,7 +323,7 @@ describe("usePriorityContextMenuItems", () => {
       const contextMenuItems = result.current.buildItems([nodes[1]]);
 
       expect(contextMenuItems).toHaveLength(1);
-      expect(contextMenuItems[0].text).toBe("Move up");
+      expect(contextMenuItems[0].text).toBe("Move up (New priority: 0)");
     });
 
     it("should use default priority property name when library element does not specify one", () => {
@@ -352,7 +352,7 @@ describe("usePriorityContextMenuItems", () => {
       const contextMenuItems = result.current.buildItems([nodes[0]]);
 
       expect(contextMenuItems).toHaveLength(1);
-      expect(contextMenuItems[0].text).toBe("Move down");
+      expect(contextMenuItems[0].text).toBe("Move down (New priority: 1)");
     });
 
     it("should only consider children of the same element type", () => {
@@ -392,7 +392,7 @@ describe("usePriorityContextMenuItems", () => {
       const contextMenuItems = result.current.buildItems([nodes[0]]);
 
       expect(contextMenuItems).toHaveLength(1);
-      expect(contextMenuItems[0].text).toBe("Move down");
+      expect(contextMenuItems[0].text).toBe("Move down (New priority: 1)");
     });
 
     it("should only consider children with the same parent", () => {
@@ -426,7 +426,7 @@ describe("usePriorityContextMenuItems", () => {
       const contextMenuItems = result.current.buildItems([nodes[0]]);
 
       expect(contextMenuItems).toHaveLength(1);
-      expect(contextMenuItems[0].text).toBe("Move down");
+      expect(contextMenuItems[0].text).toBe("Move down (New priority: 1)");
     });
   });
 });

--- a/vscode-extension/src/web/api-services/OrderedElementService.ts
+++ b/vscode-extension/src/web/api-services/OrderedElementService.ts
@@ -7,7 +7,7 @@ import {
 import { OrderedElementUtils } from "./OrderedElementUtils";
 import { ActionDifference, PatchElementRequest } from "@netcracker/qip-ui";
 import { findElementById } from "../response/chainApiUtils";
-import { getType } from "./elementUtils";
+import { ElementWithParentId, getType } from "./elementUtils";
 
 export class OrderedElementService {
   constructor(
@@ -16,27 +16,29 @@ export class OrderedElementService {
     private readonly chainElements: ElementSchema[],
   ) {}
 
-  async updatePriority(element: ElementSchema) {
+  async updatePriority(element: ElementWithParentId) {
     if (await OrderedElementService.isOrdered(element)) {
       await this.calculatePriority(element);
       return;
     }
 
-    const libraryData = await getLibraryElementByType(getType(element));
+    const libraryData = await getLibraryElementByType(getType(element.element));
 
-    if (libraryData.container && element.children) {
-      for (const child of element.children as ElementSchema[]) {
-        if (await OrderedElementService.isOrdered(child)) {
-          await this.calculatePriority(child);
+    const elementSchema = element.element;
+    if (libraryData.container && elementSchema.children) {
+      for (const child of elementSchema.children as ElementSchema[]) {
+        const childElement = {element: child, parentElementId: elementSchema.id};
+        if (await OrderedElementService.isOrdered(childElement)) {
+          await this.calculatePriority(childElement);
         }
       }
     }
   }
 
-  async calculatePriority(element: ElementSchema) {
+  async calculatePriority(element: ElementWithParentId) {
     const orderedElementUtils = await OrderedElementUtils.create(element);
     const orderedElements = orderedElementUtils.extractOtherOrderedElements(
-      this.getParentElement(element),
+      this.getParentElement(element.parentElementId!),
     );
 
     const orderNumber: number = orderedElements.filter((orderedElement) => {
@@ -49,14 +51,14 @@ export class OrderedElementService {
     orderedElementUtils.updatePriority(orderNumber);
   }
 
-  static async isOrdered(element: ElementSchema): Promise<boolean> {
-    const libraryElement = await getLibraryElementByType(getType(element));
+  static async isOrdered(element: ElementWithParentId): Promise<boolean> {
+    const libraryElement = await getLibraryElementByType(getType(element.element));
 
-    return libraryElement.ordered && element.parentElementId !== null;
+    return element.parentElementId !== undefined && libraryElement.ordered;
   }
 
   async updateProperties(
-    element: ElementSchema,
+    element: ElementWithParentId,
     elementRequest: PatchElementRequest,
   ): Promise<ActionDifference | undefined> {
     if (
@@ -75,7 +77,7 @@ export class OrderedElementService {
     }
   }
 
-  async changePriority(
+  private async changePriority(
     utils: OrderedElementUtils,
     newPriority: number,
   ): Promise<ActionDifference> {
@@ -87,48 +89,40 @@ export class OrderedElementService {
     const currentPriority: number = utils.getPriority();
 
     if (currentPriority !== newPriority) {
-      const parentElement = this.getParentElement(utils.element);
+      const parentElement = this.getParentElement(utils.parentElementId);
       const sortedElements = utils.extractSortedOrderedElements(parentElement);
 
       const currentPriorityIndex = utils.getIndex(sortedElements);
-      let newPriorityIndex = utils.getIndex(sortedElements, newPriority);
+
+      const hasExactPriorityMatch: boolean = sortedElements.some(
+        (element) => utils.getPriority(element) === newPriority,
+      );
+
+      let targetIndex = utils.getIndexToInsert(sortedElements, newPriority);
 
       utils.updatePriority(newPriority);
 
-      let elementsToUpdate = [];
-      let priorityFunction: (currentPriority: number) => number;
-
-      if (newPriority > currentPriority) {
-        if (newPriorityIndex === -1) {
-          if (currentPriorityIndex + 1 >= sortedElements.length) {
-            return chainDiff;
-          }
-          const elements = sortedElements
-            .map((element) => utils.getPriority(element))
-            .filter((priority) => priority < sortedElements.length);
-          newPriorityIndex =
-            elements.length > 0 ? Math.max(...elements) : currentPriorityIndex;
+      if (hasExactPriorityMatch) {
+        let elementsToUpdate: ElementSchema[] = [];
+        if (targetIndex > currentPriorityIndex) {
+          elementsToUpdate = sortedElements.slice(
+            currentPriorityIndex + 1,
+            targetIndex + 1,
+          );
+        } else if (targetIndex < currentPriorityIndex) {
+          elementsToUpdate = sortedElements.slice(
+            targetIndex,
+            currentPriorityIndex,
+          );
         }
-        elementsToUpdate = sortedElements.slice(
-          currentPriorityIndex + 1,
-          newPriorityIndex + 1,
-        );
-        priorityFunction = (currentPriority: number) => currentPriority - 1;
-      } else {
-        if (newPriorityIndex === -1) {
-          return chainDiff;
-        }
-        elementsToUpdate = sortedElements.slice(
-          newPriorityIndex,
-          currentPriorityIndex,
-        );
-        priorityFunction = (currentPriority: number) => currentPriority + 1;
-      }
 
-      for (const elementToUpdate of elementsToUpdate) {
-        const priority: number = utils.getPriority(elementToUpdate);
-        if (priority < sortedElements.length) {
-          utils.updatePriority(priorityFunction(priority), elementToUpdate);
+        for (const elementToUpdate of elementsToUpdate) {
+          const priority: number = utils.getPriority(elementToUpdate);
+
+          utils.updatePriority(
+            targetIndex > currentPriorityIndex ? priority - 1 : priority + 1,
+            elementToUpdate,
+          );
           chainDiff.updatedElements?.push(
             await parseElement(
               this.chainFileUri,
@@ -145,7 +139,7 @@ export class OrderedElementService {
   }
 
   async removeElementIfOrderedAndMergeDiff(
-    element: ElementSchema,
+    element: ElementWithParentId,
     chainDiff: ActionDifference,
   ): Promise<void> {
     const diff = await this.removeElementIfOrdered(element);
@@ -159,7 +153,7 @@ export class OrderedElementService {
   }
 
   private async removeElementIfOrdered(
-    element: ElementSchema,
+    element: ElementWithParentId,
   ): Promise<ActionDifference> {
     const chainDiff: ActionDifference = {
       updatedElements: [],
@@ -168,7 +162,7 @@ export class OrderedElementService {
       const utils = await OrderedElementUtils.create(element);
       const currentPriority: number = utils.getPriority();
 
-      const parentElement = this.getParentElement(element);
+      const parentElement = this.getParentElement(element.parentElementId!);
 
       if (
         currentPriority < (parentElement.children as ElementSchema[]).length
@@ -203,10 +197,10 @@ export class OrderedElementService {
     return chainDiff;
   }
 
-  private getParentElement(element: ElementSchema): ElementSchema {
+  private getParentElement(parentId: string): ElementSchema {
     return findElementById(
       this.chainElements,
-      element.parentElementId as string,
+      parentId,
     )?.element!;
   }
 }

--- a/vscode-extension/src/web/api-services/OrderedElementUtils.ts
+++ b/vscode-extension/src/web/api-services/OrderedElementUtils.ts
@@ -1,18 +1,20 @@
 import { Element as ElementSchema } from "@netcracker/qip-schemas";
 import { LibraryElement } from "@netcracker/qip-ui";
 import { getLibraryElementByType } from "../response/chainApiRead";
-import { getType } from "./elementUtils";
+import { ElementWithParentId, getType } from "./elementUtils";
 
 export class OrderedElementUtils {
   private constructor(
     public element: ElementSchema,
+    public parentElementId: string,
     private readonly libraryElement: LibraryElement,
   ) {}
 
-  static async create(element: ElementSchema): Promise<OrderedElementUtils> {
+  static async create(elementWithParentId: ElementWithParentId): Promise<OrderedElementUtils> {
     return new OrderedElementUtils(
-      element,
-      await getLibraryElementByType(getType(element)),
+      elementWithParentId.element,
+      elementWithParentId.parentElementId!,
+      await getLibraryElementByType(getType(elementWithParentId.element)),
     );
   }
 
@@ -40,6 +42,31 @@ export class OrderedElementUtils {
         ? element.id === this.element.id
         : this.getPriority(element) === priority,
     );
+  }
+
+  private getIndexByPredicate(
+    sortedElements: ElementSchema[],
+    predicate: (currentPriority: number) => boolean,
+  ): number {
+    return sortedElements.findIndex((element) =>
+      predicate(this.getPriority(element)),
+    );
+  }
+
+  getIndexToInsert(sortedElements: ElementSchema[], priority: number): number {
+    let targetIndex = this.getIndexByPredicate(
+      sortedElements,
+      (currentPriority) => currentPriority === priority,
+    );
+
+    if (targetIndex === -1) {
+      targetIndex = this.getIndexByPredicate(
+        sortedElements,
+        (currentPriority) => currentPriority > priority,
+      );
+    }
+
+    return targetIndex === -1 ? sortedElements.length - 1 : targetIndex;
   }
 
   extractOtherOrderedElements(parentElement: ElementSchema): ElementSchema[] {

--- a/vscode-extension/src/web/api-services/elementUtils.ts
+++ b/vscode-extension/src/web/api-services/elementUtils.ts
@@ -3,3 +3,8 @@ import { Element as ElementSchema } from "@netcracker/qip-schemas";
 export function getType(element: ElementSchema): string {
   return element.type as unknown as string;
 }
+
+export type ElementWithParentId = {
+  element: ElementSchema;
+  parentElementId: string | undefined;
+};

--- a/vscode-extension/src/web/response/chainApiModify.ts
+++ b/vscode-extension/src/web/response/chainApiModify.ts
@@ -221,10 +221,11 @@ export async function updateElement(
   }
 
   const chainElements = chain.content.elements as ElementSchema[];
-  let element: ElementSchema | undefined = findElementById(
+  const elementWithParentId = findElementById(
     chainElements,
     elementId,
-  )?.element;
+  );
+  let element: ElementSchema | undefined = elementWithParentId?.element;
 
   if (!element) {
     console.error(`ElementId not found`);
@@ -232,7 +233,7 @@ export async function updateElement(
   }
 
   const isChangeParent =
-    element.parentElementId !== elementRequest.parentElementId;
+    elementWithParentId?.parentId !== elementRequest.parentElementId;
 
   if (isChangeParent) {
     element = findAndRemoveElementById(chainElements, elementId)!;
@@ -256,7 +257,10 @@ export async function updateElement(
     fileUri,
     chainId,
     chainElements,
-  ).updateProperties(element, elementRequest);
+  ).updateProperties(
+    { element, parentElementId: elementWithParentId?.parentId },
+    elementRequest,
+  );
   (element as any).properties = elementRequest.properties;
 
   element.parentElementId = elementRequest.parentElementId;
@@ -587,7 +591,10 @@ export async function createElement(
     mainFolderUri,
     chainId,
     chainElements,
-  ).updatePriority(element);
+  ).updatePriority({
+    element,
+    parentElementId: elementRequest.parentElementId,
+  });
 
   await writeElementProperties(mainFolderUri, element);
   await fileApi.writeMainChain(mainFolderUri, chain);
@@ -781,7 +788,10 @@ export async function deleteElements(
       fileUri,
       chainId,
       chainElements,
-    ).removeElementIfOrderedAndMergeDiff(element, chainDiff);
+    ).removeElementIfOrderedAndMergeDiff(
+      { element, parentElementId },
+      chainDiff,
+    );
 
     const removedElement = findAndRemoveElementById(chainElements, elementId)!;
 

--- a/vscode-extension/tests/web/api-services/OrderedElementService.test.ts
+++ b/vscode-extension/tests/web/api-services/OrderedElementService.test.ts
@@ -1,5 +1,5 @@
 import { Uri } from "vscode";
-import { Element as ElementSchema } from "@netcracker/qip-schemas";
+import { DataType, Element as ElementSchema } from "@netcracker/qip-schemas";
 import { OrderedElementService } from "../../../src/web/api-services/OrderedElementService";
 import { OrderedElementUtils } from "../../../src/web/api-services/OrderedElementUtils";
 import {
@@ -34,12 +34,14 @@ describe("OrderedElementService", () => {
   // Mock OrderedElementUtils instance
   const createMockUtils = () => ({
     element: {} as ElementSchema,
+    parentElementId: "parent-id",
     extractOtherOrderedElements: jest.fn().mockReturnValue([]),
     extractSortedOrderedElements: jest.fn().mockReturnValue([]),
     getPriority: jest.fn().mockReturnValue(0),
     updatePriority: jest.fn(),
     getIndex: jest.fn().mockReturnValue(0),
     getPriorityOrUndefined: jest.fn().mockReturnValue(undefined),
+    getIndexToInsert: jest.fn().mockReturnValue(0),
   });
 
   beforeEach(() => {
@@ -56,12 +58,16 @@ describe("OrderedElementService", () => {
 
   describe("updatePriority", () => {
     it("should call calculatePriority when element is ordered", async () => {
-      const mockElement: ElementSchema = {
+      const mockElementSchema: ElementSchema = {
         id: "element-1",
         type: { name: "ordered-type" } as any,
-        parentElementId: "parent-id",
         properties: { priority: 0 },
       } as unknown as ElementSchema;
+
+      const mockElement = {
+        element: mockElementSchema,
+        parentElementId: "parent-id",
+      };
 
       mockGetLibraryElementByType.mockResolvedValue({
         ordered: true,
@@ -87,17 +93,20 @@ describe("OrderedElementService", () => {
       const orderedChild: ElementSchema = {
         id: "child-1",
         type: { name: "ordered-child-type" } as any,
-        parentElementId: "parent-id",
         properties: { priority: 0 },
       } as unknown as ElementSchema;
 
-      const mockElement: ElementSchema = {
+      const mockElementSchema: ElementSchema = {
         id: "element-1",
         type: { name: "container-type" } as any,
-        parentElementId: "parent-id",
         children: [orderedChild] as any,
         properties: {},
       } as unknown as ElementSchema;
+
+      const mockElement = {
+        element: mockElementSchema,
+        parentElementId: undefined,
+      };
 
       mockGetLibraryElementByType
         .mockResolvedValueOnce({
@@ -123,16 +132,21 @@ describe("OrderedElementService", () => {
 
       await service.updatePriority(mockElement);
 
-      expect(calculatePrioritySpy).toHaveBeenCalledWith(orderedChild);
+      expect(calculatePrioritySpy).toHaveBeenCalled();
     });
 
     it("should do nothing when element is not ordered and has no container", async () => {
-      const mockElement: ElementSchema = {
+      const mockElementSchema: ElementSchema = {
         id: "element-1",
         type: { name: "non-ordered-type" } as any,
-        parentElementId: null,
+        parentElementId: undefined,
         properties: {},
       } as unknown as ElementSchema;
+
+      const mockElement = {
+        element: mockElementSchema,
+        parentElementId: undefined,
+      };
 
       mockGetLibraryElementByType.mockResolvedValue({
         ordered: false,
@@ -157,12 +171,16 @@ describe("OrderedElementService", () => {
 
   describe("calculatePriority", () => {
     it("should correctly count ordered elements and assign order number", async () => {
-      const mockElement: ElementSchema = {
+      const mockElementSchema: ElementSchema = {
         id: "element-1",
         type: { name: "ordered-type" } as any,
-        parentElementId: "parent-id",
         properties: { priority: 0 },
       } as unknown as ElementSchema;
+
+      const mockElement = {
+        element: mockElementSchema,
+        parentElementId: "parent-id",
+      };
 
       const parentElement: ElementSchema = {
         id: "parent-id",
@@ -198,6 +216,7 @@ describe("OrderedElementService", () => {
       } as LibraryElement);
 
       const mockUtils = createMockUtils();
+      mockUtils.element = mockElementSchema;
       mockUtils.extractOtherOrderedElements.mockReturnValue(orderedElements);
       mockUtils.getPriority
         .mockReturnValueOnce(0) // for child-1
@@ -223,12 +242,16 @@ describe("OrderedElementService", () => {
     });
 
     it("should handle elements with out-of-range priorities", async () => {
-      const mockElement: ElementSchema = {
+      const mockElementSchema: ElementSchema = {
         id: "element-1",
         type: { name: "ordered-type" } as any,
-        parentElementId: "parent-id",
         properties: { priority: 0 },
       } as unknown as ElementSchema;
+
+      const mockElement = {
+        element: mockElementSchema,
+        parentElementId: "parent-id",
+      };
 
       const parentElement: ElementSchema = {
         id: "parent-id",
@@ -264,6 +287,7 @@ describe("OrderedElementService", () => {
       } as LibraryElement);
 
       const mockUtils = createMockUtils();
+      mockUtils.element = mockElementSchema;
       mockUtils.extractOtherOrderedElements.mockReturnValue(orderedElements);
       mockUtils.getPriority
         .mockReturnValueOnce(5) // out of range
@@ -290,10 +314,14 @@ describe("OrderedElementService", () => {
 
   describe("isOrdered", () => {
     it("should return true when library element is ordered and parentElementId is not null", async () => {
-      const mockElement: ElementSchema = {
+      const mockElementSchema: ElementSchema = {
         type: { name: "ordered-type" } as any,
-        parentElementId: "parent-id",
       } as unknown as ElementSchema;
+
+      const mockElement = {
+        element: mockElementSchema,
+        parentElementId: "parent-id",
+      };
 
       mockGetLibraryElementByType.mockResolvedValue({
         ordered: true,
@@ -305,10 +333,14 @@ describe("OrderedElementService", () => {
     });
 
     it("should return false when library element is not ordered", async () => {
-      const mockElement: ElementSchema = {
+      const mockElementSchema: ElementSchema = {
         type: { name: "non-ordered-type" } as any,
-        parentElementId: "parent-id",
       } as unknown as ElementSchema;
+
+      const mockElement = {
+        element: mockElementSchema,
+        parentElementId: "parent-id",
+      };
 
       mockGetLibraryElementByType.mockResolvedValue({
         ordered: false,
@@ -320,10 +352,15 @@ describe("OrderedElementService", () => {
     });
 
     it("should return false when parentElementId is null", async () => {
-      const mockElement: ElementSchema = {
+      const mockElementSchema: ElementSchema = {
         type: { name: "ordered-type" } as any,
-        parentElementId: null,
+        parentElementId: undefined,
       } as unknown as ElementSchema;
+
+      const mockElement = {
+        element: mockElementSchema,
+        parentElementId: undefined,
+      };
 
       mockGetLibraryElementByType.mockResolvedValue({
         ordered: true,
@@ -335,160 +372,18 @@ describe("OrderedElementService", () => {
     });
   });
 
-  describe("changePriority", () => {
-    it("should throw error when newPriority is negative", async () => {
-      service = new OrderedElementService(
-        mockChainFileUri,
-        mockChainId,
-        mockChainElements,
-      );
-
-      await expect(
-        service.changePriority(createMockUtils() as any, -1),
-      ).rejects.toThrow("Priority cannot be a negative number");
-    });
-
-    it("should return empty diff when priorities are equal", async () => {
-      const mockUtils = createMockUtils();
-      mockUtils.getPriority.mockReturnValue(1);
-      mockUtils.extractSortedOrderedElements.mockReturnValue([]);
-
-      (OrderedElementUtils.create as jest.Mock).mockResolvedValue(mockUtils);
-
-      service = new OrderedElementService(
-        mockChainFileUri,
-        mockChainId,
-        mockChainElements,
-      );
-
-      const result = await service.changePriority(mockUtils as any, 1);
-
-      expect(result).toEqual({ updatedElements: [] });
-    });
-
-    it("should correctly reorder elements when moving priority up", async () => {
-      const mockUtils = createMockUtils();
-      const sortedElements = [
-        {
-          id: "elem-1",
-          type: { name: "ordered-type" },
-          properties: { priority: 0 },
-        },
-        {
-          id: "elem-2",
-          type: { name: "ordered-type" },
-          properties: { priority: 1 },
-        },
-        {
-          id: "elem-3",
-          type: { name: "ordered-type" },
-          properties: { priority: 2 },
-        },
-      ] as unknown as ElementSchema[];
-
-      mockUtils.element = sortedElements[1];
-      mockUtils.getPriority.mockReturnValue(1);
-      mockUtils.extractSortedOrderedElements.mockReturnValue(sortedElements);
-      mockUtils.getIndex
-        .mockReturnValueOnce(1) // current index (priority 1)
-        .mockReturnValueOnce(0); // new priority index (priority 0)
-
-      mockParseElement.mockImplementation(() =>
-        Promise.resolve({ id: "updated-elem", type: "ordered-type" } as any),
-      );
-
-      service = new OrderedElementService(
-        mockChainFileUri,
-        mockChainId,
-        mockChainElements,
-      );
-
-      const result = await service.changePriority(mockUtils as any, 0);
-
-      expect(mockUtils.updatePriority).toHaveBeenCalled();
-      expect(result.updatedElements).toBeDefined();
-    });
-
-    it("should correctly reorder elements when moving priority down", async () => {
-      const mockUtils = createMockUtils();
-      const sortedElements = [
-        {
-          id: "elem-1",
-          type: { name: "ordered-type" },
-          properties: { priority: 0 },
-        },
-        {
-          id: "elem-2",
-          type: { name: "ordered-type" },
-          properties: { priority: 1 },
-        },
-        {
-          id: "elem-3",
-          type: { name: "ordered-type" },
-          properties: { priority: 2 },
-        },
-      ] as unknown as ElementSchema[];
-
-      mockUtils.element = sortedElements[0];
-      mockUtils.getPriority.mockReturnValue(0);
-      mockUtils.extractSortedOrderedElements.mockReturnValue(sortedElements);
-      mockUtils.getIndex.mockReturnValue(0); // current index
-
-      mockParseElement.mockImplementation(() =>
-        Promise.resolve({ id: "updated-elem", type: "ordered-type" } as any),
-      );
-
-      service = new OrderedElementService(
-        mockChainFileUri,
-        mockChainId,
-        mockChainElements,
-      );
-
-      const result = await service.changePriority(mockUtils as any, 2);
-
-      expect(mockUtils.updatePriority).toHaveBeenCalled();
-      expect(result.updatedElements).toBeDefined();
-    });
-
-    it("should handle edge case when newPriorityIndex is -1 when moving down", async () => {
-      const mockUtils = createMockUtils();
-      const sortedElements = [
-        {
-          id: "elem-1",
-          type: { name: "ordered-type" },
-          properties: { priority: 0 },
-        },
-      ] as unknown as ElementSchema[];
-
-      mockUtils.element = sortedElements[0];
-      mockUtils.getPriority.mockReturnValue(0);
-      mockUtils.extractSortedOrderedElements.mockReturnValue(sortedElements);
-      mockUtils.getIndex
-        .mockReturnValueOnce(0) // current index
-        .mockReturnValueOnce(-1); // new priority index (not found)
-
-      (OrderedElementUtils.create as jest.Mock).mockResolvedValue(mockUtils);
-
-      service = new OrderedElementService(
-        mockChainFileUri,
-        mockChainId,
-        mockChainElements,
-      );
-
-      const result = await service.changePriority(mockUtils as any, 0);
-
-      expect(result).toEqual({ updatedElements: [] });
-    });
-  });
-
   describe("removeElementIfOrderedAndMergeDiff", () => {
     it("should merge diff without duplicates", async () => {
-      const elementToRemove: ElementSchema = {
+      const elementToRemoveSchema: ElementSchema = {
         id: "element-1",
         type: { name: "ordered-type" } as any,
-        parentElementId: "parent-id",
         properties: { priority: 1 },
       } as unknown as ElementSchema;
+
+      const elementToRemove = {
+        element: elementToRemoveSchema,
+        parentElementId: "parent-id",
+      };
 
       const parentElement: ElementSchema = {
         id: "parent-id",
@@ -516,7 +411,7 @@ describe("OrderedElementService", () => {
       } as LibraryElement);
 
       const mockUtils = createMockUtils();
-      mockUtils.element = elementToRemove;
+      mockUtils.element = elementToRemoveSchema;
       mockUtils.extractSortedOrderedElements.mockReturnValue([
         {
           id: "elem-0",
@@ -537,6 +432,7 @@ describe("OrderedElementService", () => {
       mockUtils.getPriority
         .mockReturnValueOnce(1) // For utils.getPriority() - the element's own priority
         .mockReturnValueOnce(2); // For the priority of elem-2 in the loop
+
       mockUtils.getIndex.mockReturnValue(1); // Finds element-1 at index 1
 
       mockParseElement.mockImplementation((uri, element) =>
@@ -567,18 +463,22 @@ describe("OrderedElementService", () => {
     });
 
     it("should not add duplicates to chainDiff", async () => {
-      const mockElement: ElementSchema = {
-        id: "element-1", // This is the element being removed
+      const elementToRemoveSchema: ElementSchema = {
+        id: "element-1",
         type: { name: "ordered-type" } as any,
-        parentElementId: "parent-id",
         properties: { priority: 1 },
       } as unknown as ElementSchema;
+
+      const elementToRemove = {
+        element: elementToRemoveSchema,
+        parentElementId: "parent-id",
+      };
 
       const parentElement: ElementSchema = {
         id: "parent-id",
         children: [
           {
-            id: "element-1", // The element being removed should be here
+            id: "element-1",
             type: { name: "ordered-type" } as any,
             properties: { priority: 1 },
           },
@@ -595,7 +495,7 @@ describe("OrderedElementService", () => {
       } as LibraryElement);
 
       const mockUtils = createMockUtils();
-      mockUtils.element = mockElement;
+      mockUtils.element = elementToRemoveSchema;
       // Include the element being removed in the sorted list
       mockUtils.extractSortedOrderedElements.mockReturnValue([
         {
@@ -636,7 +536,10 @@ describe("OrderedElementService", () => {
         updatedElements: [existingElement],
       } as any;
 
-      await service.removeElementIfOrderedAndMergeDiff(mockElement, chainDiff);
+      await service.removeElementIfOrderedAndMergeDiff(
+        elementToRemove,
+        chainDiff,
+      );
 
       // After removing element-1 at index 0, elem-2 gets priority decremented
       // But elem-2's id ("elem-2") is NOT "element-1", so no duplicate
@@ -644,12 +547,17 @@ describe("OrderedElementService", () => {
     });
 
     it("should handle element with priority at the end", async () => {
-      const mockElement: ElementSchema = {
+      const elementToRemoveSchema: ElementSchema = {
         id: "element-1",
         type: { name: "ordered-type" } as any,
         parentElementId: "parent-id",
         properties: { priority: 2 },
       } as unknown as ElementSchema;
+
+      const elementToRemove = {
+        element: elementToRemoveSchema,
+        parentElementId: "parent-id",
+      };
 
       const parentElement: ElementSchema = {
         id: "parent-id",
@@ -672,7 +580,7 @@ describe("OrderedElementService", () => {
       } as LibraryElement);
 
       const mockUtils = createMockUtils();
-      mockUtils.element = mockElement;
+      mockUtils.element = elementToRemoveSchema;
       mockUtils.extractSortedOrderedElements.mockReturnValue([
         {
           id: "elem-1",
@@ -698,19 +606,26 @@ describe("OrderedElementService", () => {
 
       const chainDiff: ActionDifference = { updatedElements: [] } as any;
 
-      await service.removeElementIfOrderedAndMergeDiff(mockElement, chainDiff);
+      await service.removeElementIfOrderedAndMergeDiff(
+        elementToRemove,
+        chainDiff,
+      );
 
       // Should not update anything when element is at the end
       expect(chainDiff.updatedElements).toHaveLength(0);
     });
 
     it("should do nothing when element is not ordered", async () => {
-      const mockElement = {
+      const mockElementSchema = {
         id: "element-1",
         type: { name: "non-ordered-type" } as any,
-        parentElementId: "parent-id",
         properties: {},
       } as unknown as ElementSchema;
+
+      const mockElement = {
+        element: mockElementSchema,
+        parentElementId: "parent-id",
+      };
 
       mockGetLibraryElementByType.mockResolvedValue({
         ordered: false,
@@ -732,12 +647,16 @@ describe("OrderedElementService", () => {
 
   describe("updateProperties", () => {
     it("should return undefined when parentElementId has not changed", async () => {
-      const mockElement = {
+      const mockElementSchema = {
         id: "element-1",
         type: { name: "ordered-type" } as any,
-        parentElementId: "parent-id",
         properties: {},
       } as unknown as ElementSchema;
+
+      const mockElement = {
+        element: mockElementSchema,
+        parentElementId: "parent-id",
+      };
 
       const elementRequest = {
         parentElementId: "parent-id",
@@ -759,12 +678,16 @@ describe("OrderedElementService", () => {
     });
 
     it("should return undefined when element is not ordered", async () => {
-      const mockElement = {
+      const mockElementSchema = {
         id: "element-1",
         type: { name: "non-ordered-type" } as any,
-        parentElementId: "parent-id",
         properties: {},
       } as unknown as ElementSchema;
+
+      const mockElement = {
+        element: mockElementSchema,
+        parentElementId: "parent-id",
+      };
 
       const elementRequest = {
         parentElementId: "parent-id",
@@ -790,12 +713,16 @@ describe("OrderedElementService", () => {
     });
 
     it("should call changePriority when priority changes on ordered element", async () => {
-      const mockElement = {
+      const mockElementSchema = {
         id: "element-1",
         type: { name: "ordered-type" } as any,
-        parentElementId: "parent-id",
         properties: {},
       } as unknown as ElementSchema;
+
+      const mockElement = {
+        element: mockElementSchema,
+        parentElementId: "parent-id",
+      };
 
       const elementRequest = {
         parentElementId: "parent-id",
@@ -807,7 +734,7 @@ describe("OrderedElementService", () => {
       } as LibraryElement);
 
       const mockUtils = createMockUtils();
-      mockUtils.element = mockElement;
+      mockUtils.element = mockElementSchema;
       mockUtils.getPriorityOrUndefined.mockReturnValue(2);
 
       // Mock for OrderedElementUtils.create call inside updateProperties
@@ -830,44 +757,191 @@ describe("OrderedElementService", () => {
       expect(isOrderedSpy).toHaveBeenCalledWith(mockElement);
       expect(changePrioritySpy).toHaveBeenCalledWith(mockUtils, 2);
     });
-  });
 
-  describe("getParentElement", () => {
-    it("should return parent element by ID lookup", async () => {
-      const parentElement = {
-        id: "parent-id",
-        type: { name: "parent-type" } as any,
-        children: [],
-        properties: {},
-      } as unknown as ElementSchema;
+    describe("updateProperties cases", () => {
+      // Parameterized tests for priority change scenarios
+      const priorityChangeCases: Array<
+        [
+          string,
+          {
+            existingElements: { id: string; priority: number }[];
+            targetElementId: string;
+            newPriority: number;
+            expectedUpdates: { id: string; priority: number }[];
+          },
+        ]
+      > = [
+        [
+          "should not change priority of other elements when moving to non-existent priority",
+          {
+            existingElements: [
+              { id: "elem-1", priority: 0 },
+              { id: "elem-2", priority: 1 },
+            ],
+            targetElementId: "elem-1",
+            newPriority: 5,
+            expectedUpdates: [],
+          },
+        ],
+        [
+          "should not change priorities when moving to higher non-overlapping priority",
+          {
+            existingElements: [
+              { id: "elem-1", priority: 0 },
+              { id: "elem-2", priority: 1 },
+              { id: "elem-3", priority: 40 },
+            ],
+            targetElementId: "elem-2",
+            newPriority: 3,
+            expectedUpdates: [],
+          },
+        ],
+        [
+          "should not change priorities when moving to lower non-overlapping priority",
+          {
+            existingElements: [
+              { id: "elem-1", priority: 0 },
+              { id: "elem-2", priority: 2 },
+              { id: "elem-3", priority: 40 },
+            ],
+            targetElementId: "elem-2",
+            newPriority: 1,
+            expectedUpdates: [],
+          },
+        ],
+        [
+          "should not change priorities with unordered initial priorities",
+          {
+            existingElements: [
+              { id: "elem-1", priority: 1 },
+              { id: "elem-2", priority: 0 },
+              { id: "elem-3", priority: 40 },
+            ],
+            targetElementId: "elem-2",
+            newPriority: 2,
+            expectedUpdates: [],
+          },
+        ],
+        [
+          "should shift priorities when moving to existing priority",
+          {
+            existingElements: [
+              { id: "elem-1", priority: 1 },
+              { id: "elem-2", priority: 39 },
+              { id: "elem-3", priority: 40 },
+              { id: "elem-4", priority: 38 },
+            ],
+            targetElementId: "elem-4",
+            newPriority: 40,
+            expectedUpdates: [
+              { id: "elem-3", priority: 39 },
+              { id: "elem-2", priority: 38 },
+            ],
+          },
+        ],
+      ];
 
-      const mockElement = {
-        id: "element-1",
-        type: { name: "child-type" } as any,
-        parentElementId: "parent-id",
-        properties: {},
-      };
+      test.each(priorityChangeCases)("%s", async (description, testData) => {
+        const {
+          existingElements,
+          targetElementId,
+          newPriority,
+          expectedUpdates,
+        } = testData;
 
-      mockChainElements = [parentElement];
-      mockFindElementById.mockReturnValue({
-        element: parentElement,
-        parentId: undefined,
+        const orderedElements: ElementSchema[] = existingElements.map(
+          (elem) =>
+            ({
+              id: elem.id,
+              type: "ordered-type" as unknown as DataType,
+              properties: { priority: elem.priority },
+            }) as unknown as ElementSchema,
+        );
+
+        const mockElementSchema = orderedElements.find(
+          (elem) => elem.id === targetElementId,
+        )!;
+
+        const mockElement = {
+          element: mockElementSchema,
+          parentElementId: "parent-id",
+        };
+
+        const elementRequest = {
+          parentElementId: "parent-id",
+          properties: { priority: newPriority },
+        };
+
+        mockGetLibraryElementByType.mockResolvedValue({
+          ordered: true,
+        } as LibraryElement);
+
+        const { OrderedElementUtils: ActualUtils } = jest.requireActual(
+          "../../../src/web/api-services/OrderedElementUtils",
+        );
+
+        const utils = await ActualUtils.create(mockElement);
+
+        (OrderedElementUtils.create as jest.Mock).mockResolvedValue(utils);
+        const updatePrioritySpy = jest.spyOn(utils, "updatePriority");
+
+        mockFindElementById.mockImplementation(
+          (elements, elementId: string) => {
+            if (elementId === "parent-id") {
+              const parentElement: ElementSchema = {
+                id: "parent-id",
+                children: orderedElements,
+              } as unknown as ElementSchema;
+
+              return { element: parentElement, parentId: undefined };
+            }
+            return {
+              element: { id: elementId } as unknown as ElementSchema,
+              parentId: undefined,
+            };
+          },
+        );
+
+        const isOrderedSpy = jest
+          .spyOn(OrderedElementService, "isOrdered")
+          .mockResolvedValue(true);
+
+        service = new OrderedElementService(
+          mockChainFileUri,
+          mockChainId,
+          mockChainElements,
+        );
+
+        const result = await service.updateProperties(
+          mockElement,
+          elementRequest as any,
+        );
+
+        // Verify updatePriority calls for expected updates
+        const updatePriorityCalls = updatePrioritySpy.mock.calls;
+
+        // First call should be for the target element's new priority
+        expect(updatePriorityCalls[0]).toEqual([newPriority]);
+
+        // Check other priority updates
+        if (expectedUpdates.length > 0) {
+          const otherCalls = updatePriorityCalls.slice(1);
+          expectedUpdates.forEach((expected, index) => {
+            // Find the call that corresponds to this expected update
+            const call = otherCalls.find(
+              (c: any[]) =>
+                expected.priority === c[0] &&
+                orderedElements.some((e: any) => e.id === expected.id),
+            );
+            expect(call).toBeTruthy();
+          });
+        } else {
+          // No other updates expected
+          expect(updatePrioritySpy).toHaveBeenCalledTimes(1);
+        }
+
+        expect(isOrderedSpy).toHaveBeenCalledWith(mockElement);
       });
-
-      service = new OrderedElementService(
-        mockChainFileUri,
-        mockChainId,
-        mockChainElements,
-      );
-
-      // Access private method for testing
-      const result = (service as any).getParentElement(mockElement);
-
-      expect(mockFindElementById).toHaveBeenCalledWith(
-        mockChainElements,
-        "parent-id",
-      );
-      expect(result).toEqual(parentElement);
     });
   });
 });

--- a/vscode-extension/tests/web/api-services/OrderedElementUtils.test.ts
+++ b/vscode-extension/tests/web/api-services/OrderedElementUtils.test.ts
@@ -37,7 +37,10 @@ describe("OrderedElementUtils", () => {
     it("should create OrderedElementUtils instance with element and library data", async () => {
       mockGetLibraryElementByType.mockResolvedValue(mockLibraryElement);
 
-      const result = await OrderedElementUtils.create(mockElement);
+      const result = await OrderedElementUtils.create({
+        element: mockElement,
+        parentElementId: "parent-id",
+      });
 
       expect(mockGetLibraryElementByType).toHaveBeenCalledWith({
         name: "test-ordered-type",
@@ -51,7 +54,10 @@ describe("OrderedElementUtils", () => {
         ordered: true,
       } as LibraryElement);
 
-      const result = await OrderedElementUtils.create(mockElement);
+      const result = await OrderedElementUtils.create({
+        element: mockElement,
+        parentElementId: "parent-id",
+      });
 
       expect(getPriorityProperty(result)).toBe("priority");
     });
@@ -60,7 +66,10 @@ describe("OrderedElementUtils", () => {
   describe("getPriority", () => {
     beforeEach(async () => {
       mockGetLibraryElementByType.mockResolvedValue(mockLibraryElement);
-      utils = await OrderedElementUtils.create(mockElement);
+      utils = await OrderedElementUtils.create({
+        element: mockElement,
+        parentElementId: "parent-id",
+      });
     });
 
     it("should return priority from element when called without arguments", () => {
@@ -89,9 +98,10 @@ describe("OrderedElementUtils", () => {
         properties: { customPriority: 3 },
       } as ElementSchema;
 
-      const customUtils = await OrderedElementUtils.create(
-        elementWithCustomPriority,
-      );
+      const customUtils = await OrderedElementUtils.create({
+        element: elementWithCustomPriority,
+        parentElementId: "parent-id",
+      });
       const result = customUtils.getPriority();
 
       expect(result).toBe(3);
@@ -101,7 +111,10 @@ describe("OrderedElementUtils", () => {
   describe("getPriorityOrUndefined", () => {
     beforeEach(async () => {
       mockGetLibraryElementByType.mockResolvedValue(mockLibraryElement);
-      utils = await OrderedElementUtils.create(mockElement);
+      utils = await OrderedElementUtils.create({
+        element: mockElement,
+        parentElementId: "parent-id",
+      });
     });
 
     it("should return priority value when property exists", () => {
@@ -120,7 +133,10 @@ describe("OrderedElementUtils", () => {
   describe("updatePriority", () => {
     beforeEach(async () => {
       mockGetLibraryElementByType.mockResolvedValue(mockLibraryElement);
-      utils = await OrderedElementUtils.create(mockElement);
+      utils = await OrderedElementUtils.create({
+        element: mockElement,
+        parentElementId: "parent-id",
+      });
     });
 
     it("should update priority on the element when called without element argument", () => {
@@ -155,9 +171,10 @@ describe("OrderedElementUtils", () => {
         properties: { customPriority: 1 },
       } as ElementSchema;
 
-      const customUtils = await OrderedElementUtils.create(
-        elementWithCustomPriority,
-      );
+      const customUtils = await OrderedElementUtils.create({
+        element: elementWithCustomPriority,
+        parentElementId: "parent-id",
+      });
       customUtils.updatePriority(2);
 
       expect((elementWithCustomPriority.properties as any).customPriority).toBe(
@@ -169,7 +186,10 @@ describe("OrderedElementUtils", () => {
   describe("getIndex", () => {
     beforeEach(async () => {
       mockGetLibraryElementByType.mockResolvedValue(mockLibraryElement);
-      utils = await OrderedElementUtils.create(mockElement);
+      utils = await OrderedElementUtils.create({
+        element: mockElement,
+        parentElementId: "parent-id",
+      });
     });
 
     it("should find index by element id when priority is undefined", () => {
@@ -241,7 +261,10 @@ describe("OrderedElementUtils", () => {
   describe("extractOtherOrderedElements", () => {
     beforeEach(async () => {
       mockGetLibraryElementByType.mockResolvedValue(mockLibraryElement);
-      utils = await OrderedElementUtils.create(mockElement);
+      utils = await OrderedElementUtils.create({
+        element: mockElement,
+        parentElementId: "parent-id",
+      });
     });
 
     it("should return children with same type excluding current element", () => {
@@ -301,7 +324,10 @@ describe("OrderedElementUtils", () => {
   describe("extractSortedOrderedElements", () => {
     beforeEach(async () => {
       mockGetLibraryElementByType.mockResolvedValue(mockLibraryElement);
-      utils = await OrderedElementUtils.create(mockElement);
+      utils = await OrderedElementUtils.create({
+        element: mockElement,
+        parentElementId: "parent-id",
+      });
     });
 
     it("should sort children by priority ascending", () => {


### PR DESCRIPTION
fixed scenarios:
1 case: 
given: two elements with priorities 0 and 1
steps: change priority of the first from 0 to 5
expected: priority of the second element must not be changed

2 case:
given: three elements with priorities 0, 1, 40
steps: change priority of the second from 1 to 3
expected: priorities of the first and third elements must not be changed and no error message thrown

3 case:
given: three elements with priorities 0, 2, 40
steps: change priority of the second from 2 to 1
expected: priorities of the others must not be changed
actual: priority of the first changed from 0 to 1

4 case:
given: three elements with priorities 1, 0, 40
steps: change priority of the second from 0 to 2
expected: priorities of the others must not be changed
actual: priority of the first changed from 1 to 0

5 case:
given: elements with priorities 1, 39, 40, 38
steps: change priority of the last from 38 to 40
expected: priority of the third element must change from 40 to 39, of the second - from 39 to 38
actual: priority of the third element not changed