### PR TITLE
chore: update community files

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -11,6 +11,7 @@ safe and productive community for all.
 
 The guideline is aimed to support a community where all people should feel safe to participate,
 introduce new ideas and inspire others, regardless of:
+
 * Age
 * Gender
 * Gender identity or expression
@@ -34,6 +35,7 @@ introduce new ideas and inspire others, regardless of:
 ## Our Standards
 
 We are welcoming the following behavior:
+
 * Be respectful for different ideas, opinions and points of view
 * Be constructive and professional
 * Use inclusive language
@@ -41,6 +43,7 @@ We are welcoming the following behavior:
 * Focus on the best results for the community
 
 The following behavior is unacceptable:
+
 * Violence, threats of violence, or inciting others to commit self-harm
 * Personal attacks, trolling, intentionally spreading misinformation, insulting/derogatory comments
 * Public or private harassment
@@ -62,7 +65,7 @@ that they deem inappropriate, threatening, offensive, or harmful.
 ## Reporting
 
 If you believe you’re experiencing unacceptable behavior that will not be tolerated as outlined above,
-please report to `plutosdev@gmail.com`. All complaints will be reviewed and investigated and will result in a response
+please report to `opensourcegroup@netcracker.com`. All complaints will be reviewed and investigated and will result in a response
 that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality
 with regard to the reporter of an incident.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,9 @@ We'd love to accept patches and contributions to this project.
 Please, follow these guidelines to make the contribution process easy and effective for everyone involved.
 
 ## Contributor License Agreement
-You must sign the [Contributor License Agreement](https://pages.netcracker.com/cla-main.html) in order to contribute.
+
+You must sign the [Contributor License Agreement](https://github.com/Netcracker/qubership-workflow-hub/blob/main/CLA/cla.md) in order to contribute.
 
 ## Code of Conduct
-Please make sure to read and follow the [Code of Conduct](CODE-OF-CONDUCT.md).
 
+Please make sure to read and follow the [Code of Conduct](CODE-OF-CONDUCT.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,10 @@
-# Security Reporting Process
+# Security Policy
 
-Please, report any security issue to `plutosdev@gmail.com` where the issue will be triaged appropriately.
+## Reporting a Vulnerability
 
-If you know of a publicly disclosed security vulnerability please IMMEDIATELY email `plutosdev@gmail.com`
+Please, report any security issue to `opensourcegroup@netcracker.com` where the issue will be triaged appropriately.
+
+If you know of a publicly disclosed security vulnerability please IMMEDIATELY email `opensourcegroup@netcracker.com`
 to inform the team about the vulnerability, so we may start the patch, release, and communication process.
 
 ## Security Release Process


### PR DESCRIPTION
## Summary

- Update SECURITY.md, CODE-OF-CONDUCT.md, and CONTRIBUTING.md from the central Netcracker templates.
- Replace outdated personal contact email with opensourcegroup@netcracker.com.
- Update the CLA link to the current shared document.

## Files

- SECURITY.md
- CODE-OF-CONDUCT.md
- CONTRIBUTING.md