### PR TITLE
fix(engine-0.3): Fix orphaned Consul sessions causing stale engines-state keys #277

### DIFF
--- a/engine/src/main/java/org/qubership/integration/platform/engine/consul/ConsulClient.java
+++ b/engine/src/main/java/org/qubership/integration/platform/engine/consul/ConsulClient.java
@@ -62,14 +62,21 @@ public class ConsulClient {
     }
 
     public void renewSession(String activeSessionId) {
-        HttpEntity<Object> entity = new HttpEntity<>(buildCommonHeaders());
-        ResponseEntity<String> response = restTemplate.exchange(consulUrl + RENEW_SESSION_PATH + "/" + activeSessionId,
-            HttpMethod.PUT, entity, String.class);
+        try {
+            HttpEntity<Object> entity = new HttpEntity<>(buildCommonHeaders());
+            ResponseEntity<String> response = restTemplate.exchange(consulUrl + RENEW_SESSION_PATH + "/" + activeSessionId,
+                HttpMethod.PUT, entity, String.class);
 
-        if (response.getStatusCode() != HttpStatus.OK) {
-            log.error("Failed to renew session in consul, code: {}, body: {}",
-                response.getStatusCode(), response.getBody());
-            throw new RuntimeException("Failed to renew session in consul, response with non 2xx code");
+            if (response.getStatusCode() != HttpStatus.OK) {
+                log.error("Failed to renew session in consul, code: {}, body: {}",
+                    response.getStatusCode(), response.getBody());
+                throw new RuntimeException("Failed to renew session in consul, response with non 2xx code");
+            }
+        } catch (HttpClientErrorException hcee) {
+            if (hcee.getStatusCode() == HttpStatus.NOT_FOUND) {
+                throw new InvalidConsulSessionException(activeSessionId, hcee);
+            }
+            throw hcee;
         }
     }
 
@@ -99,6 +106,11 @@ public class ConsulClient {
             log.error("Failed to delete session from consul, code: {}, body: {}",
                 response.getStatusCode(), response.getBody());
             throw new RuntimeException("Failed to delete session from consul, response with non 2xx code");
+        }
+
+        if ("false".equalsIgnoreCase(response.getBody())) {
+            log.debug("Consul session already gone: {}", previousSessionId);
+            return;
         }
 
         if (!"true".equalsIgnoreCase(response.getBody())) {

--- a/engine/src/main/java/org/qubership/integration/platform/engine/consul/ConsulService.java
+++ b/engine/src/main/java/org/qubership/integration/platform/engine/consul/ConsulService.java
@@ -132,11 +132,7 @@ public class ConsulService {
             if (activeSessionId == null) {
                 log.debug("Create consul session");
                 if (previousSessionId != null) {
-                    try {
-                        client.deleteSession(previousSessionId);
-                        previousSessionId = null;
-                    } catch (Exception e) {
-                        log.warn("Failed to delete previous consul session {}, will retry", previousSessionId, e);
+                    if (!deletePreviousSession()) {
                         return;
                     }
                 }
@@ -357,5 +353,24 @@ public class ConsulService {
     private static boolean filterL1NonEmptyPaths(String pathPrefix, String path) {
         String[] split = path.substring(pathPrefix.length()).split("/");
         return split.length == 1 && StringUtils.isNotEmpty(split[0]);
+    }
+
+    private boolean deletePreviousSession() {
+        if (previousSessionId == null) {
+            return true;
+        }
+
+        try {
+            client.deleteSession(previousSessionId);
+            previousSessionId = null;
+            return true;
+        } catch (Exception e) {
+            log.warn(
+                "Failed to delete previous consul session {}, will retry",
+                previousSessionId,
+                e
+            );
+            return false;
+        }
     }
 }

--- a/engine/src/main/java/org/qubership/integration/platform/engine/consul/ConsulService.java
+++ b/engine/src/main/java/org/qubership/integration/platform/engine/consul/ConsulService.java
@@ -132,8 +132,13 @@ public class ConsulService {
             if (activeSessionId == null) {
                 log.debug("Create consul session");
                 if (previousSessionId != null) {
-                    client.deleteSession(previousSessionId);
-                    previousSessionId = null;
+                    try {
+                        client.deleteSession(previousSessionId);
+                        previousSessionId = null;
+                    } catch (Exception e) {
+                        log.warn("Failed to delete previous consul session {}, will retry", previousSessionId, e);
+                        return;
+                    }
                 }
                 activeSessionId = client.createSession(SESSION_PREFIX + UUID.randomUUID(),
                     SESSION_BEHAVIOR, SESSION_TTL_STRING);
@@ -142,10 +147,16 @@ public class ConsulService {
                 log.debug("Renew consul session");
                 client.renewSession(activeSessionId);
             }
-        } catch (Exception e) {
-            log.error("Failed to create/renew consul session", e);
+        } catch (InvalidConsulSessionException e) {
+            log.warn("Consul session expired, scheduling destroy and creating a new one: {}", activeSessionId);
             previousSessionId = activeSessionId;
             activeSessionId = null;
+        } catch (Exception e) {
+            if (activeSessionId != null) {
+                log.warn("Failed to renew consul session, will retry with the same session id", e);
+            } else {
+                log.error("Failed to create consul session", e);
+            }
         }
     }
 

--- a/engine/src/main/java/org/qubership/integration/platform/engine/consul/InvalidConsulSessionException.java
+++ b/engine/src/main/java/org/qubership/integration/platform/engine/consul/InvalidConsulSessionException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024-2025 NetCracker Technology Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.qubership.integration.platform.engine.consul;
+
+public class InvalidConsulSessionException extends RuntimeException {
+    public InvalidConsulSessionException(String sessionId, Throwable cause) {
+        super("Consul session is invalid or expired: " + sessionId, cause);
+    }
+}

--- a/engine/src/test/java/org/qubership/integration/platform/engine/consul/ConsulClientTest.java
+++ b/engine/src/test/java/org/qubership/integration/platform/engine/consul/ConsulClientTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2024-2025 NetCracker Technology Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.qubership.integration.platform.engine.consul;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ConsulClientTest {
+
+    private static final String SESSION_ID = "session-123";
+
+    private RestTemplate restTemplate;
+    private ConsulClient client;
+
+    @BeforeEach
+    void setUp() {
+        restTemplate = mock(RestTemplate.class);
+        client = new ConsulClient(restTemplate, "http://consul:8500");
+    }
+
+    @Test
+    void renewSessionSucceedsWhenConsulReturnsOk() {
+        when(restTemplate.exchange(anyString(), any(), any(), any(Class.class)))
+                .thenReturn(new ResponseEntity<>("", HttpStatus.OK));
+
+        assertDoesNotThrow(() -> client.renewSession(SESSION_ID));
+    }
+
+    @Test
+    void renewSessionThrowsInvalidConsulSessionExceptionWhenSessionNotFound() {
+        HttpClientErrorException notFound = HttpClientErrorException.create(
+                HttpStatus.NOT_FOUND, "Not Found", HttpHeaders.EMPTY, null, null);
+        when(restTemplate.exchange(anyString(), any(), any(), any(Class.class)))
+                .thenThrow(notFound);
+
+        InvalidConsulSessionException exception = assertThrows(
+                InvalidConsulSessionException.class, () -> client.renewSession(SESSION_ID));
+
+        assertEquals("Consul session is invalid or expired: " + SESSION_ID, exception.getMessage());
+        assertEquals(notFound, exception.getCause());
+    }
+
+    @Test
+    void renewSessionRethrowsOtherHttpClientErrors() {
+        HttpClientErrorException badRequest = HttpClientErrorException.create(
+                HttpStatus.BAD_REQUEST, "Bad Request", HttpHeaders.EMPTY, null, null);
+        when(restTemplate.exchange(anyString(), any(), any(), any(Class.class)))
+                .thenThrow(badRequest);
+
+        HttpClientErrorException exception = assertThrows(
+                HttpClientErrorException.class, () -> client.renewSession(SESSION_ID));
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+    }
+
+    @Test
+    void renewSessionThrowsWhenConsulReturnsNonOkStatus() {
+        when(restTemplate.exchange(anyString(), any(), any(), any(Class.class)))
+                .thenReturn(new ResponseEntity<>("error", HttpStatus.INTERNAL_SERVER_ERROR));
+
+        assertThrows(RuntimeException.class, () -> client.renewSession(SESSION_ID));
+    }
+
+    @Test
+    void deleteSessionReturnsWhenSessionAlreadyGone() {
+        when(restTemplate.exchange(contains("destroy"), any(), any(), any(Class.class), anyMap()))
+                .thenReturn(new ResponseEntity<>("false", HttpStatus.OK));
+
+        assertDoesNotThrow(() -> client.deleteSession(SESSION_ID));
+    }
+
+    @Test
+    void deleteSessionSucceedsWhenConsulReturnsTrue() {
+        when(restTemplate.exchange(contains("destroy"), any(), any(), any(Class.class), anyMap()))
+                .thenReturn(new ResponseEntity<>("true", HttpStatus.OK));
+
+        assertDoesNotThrow(() -> client.deleteSession(SESSION_ID));
+    }
+
+    @Test
+    void deleteSessionThrowsWhenConsulReturnsUnexpectedBody() {
+        when(restTemplate.exchange(contains("destroy"), any(), any(), any(Class.class), anyMap()))
+                .thenReturn(new ResponseEntity<>("unexpected", HttpStatus.OK));
+
+        assertThrows(RuntimeException.class, () -> client.deleteSession(SESSION_ID));
+    }
+
+    @Test
+    void deleteSessionThrowsWhenConsulReturnsNonOkStatus() {
+        when(restTemplate.exchange(contains("destroy"), any(), any(), any(Class.class), anyMap()))
+                .thenReturn(new ResponseEntity<>("true", HttpStatus.INTERNAL_SERVER_ERROR));
+
+        assertThrows(RuntimeException.class, () -> client.deleteSession(SESSION_ID));
+    }
+}

--- a/engine/src/test/java/org/qubership/integration/platform/engine/consul/ConsulServiceTest.java
+++ b/engine/src/test/java/org/qubership/integration/platform/engine/consul/ConsulServiceTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2024-2025 NetCracker Technology Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.qubership.integration.platform.engine.consul;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.qubership.integration.platform.engine.configuration.ServerConfiguration;
+import org.qubership.integration.platform.engine.events.ConsulSessionCreatedEvent;
+import org.qubership.integration.platform.engine.model.deployment.engine.EngineInfo;
+import org.springframework.context.ApplicationEventPublisher;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ConsulServiceTest {
+
+    private static final String FIRST_SESSION_ID = "first-session-id";
+    private static final String SECOND_SESSION_ID = "second-session-id";
+
+    private ConsulClient client;
+    private ApplicationEventPublisher applicationEventPublisher;
+    private ConsulService consulService;
+
+    @BeforeEach
+    void setUp() {
+        client = mock(ConsulClient.class);
+        ObjectMapper objectMapper = mock(ObjectMapper.class);
+        applicationEventPublisher = mock(ApplicationEventPublisher.class);
+
+        ServerConfiguration serverConfiguration = mock(ServerConfiguration.class);
+        when(serverConfiguration.getEngineInfo()).thenReturn(EngineInfo.builder()
+                .engineDeploymentName("engine")
+                .domain("domain")
+                .host("host")
+                .build());
+
+        consulService = new ConsulService(
+                client,
+                serverConfiguration,
+                objectMapper,
+                applicationEventPublisher,
+                new ConsulKeyValidator());
+    }
+
+    @Test
+    void createOrRenewSessionCreatesSessionAndPublishesEventWhenNoActiveSession() {
+        when(client.createSession(anyString(), anyString(), anyString()))
+                .thenReturn(FIRST_SESSION_ID);
+
+        consulService.createOrRenewSession();
+
+        assertEquals(FIRST_SESSION_ID, consulService.getActiveSessionId());
+        verify(applicationEventPublisher).publishEvent(any(ConsulSessionCreatedEvent.class));
+    }
+
+    @Test
+    void createOrRenewSessionRenewsWhenActiveSessionExists() {
+        when(client.createSession(anyString(), anyString(), anyString()))
+                .thenReturn(FIRST_SESSION_ID);
+
+        consulService.createOrRenewSession();
+        consulService.createOrRenewSession();
+
+        assertEquals(FIRST_SESSION_ID, consulService.getActiveSessionId());
+        verify(client).renewSession(FIRST_SESSION_ID);
+        verify(client, times(1)).createSession(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void createOrRenewSessionDeletesPreviousSessionBeforeCreatingNewOne() {
+        when(client.createSession(anyString(), anyString(), anyString()))
+                .thenReturn(FIRST_SESSION_ID, SECOND_SESSION_ID);
+        doThrow(new InvalidConsulSessionException(FIRST_SESSION_ID, new RuntimeException("not found")))
+                .when(client).renewSession(FIRST_SESSION_ID);
+
+        consulService.createOrRenewSession();
+        consulService.createOrRenewSession();
+        consulService.createOrRenewSession();
+
+        assertEquals(SECOND_SESSION_ID, consulService.getActiveSessionId());
+        verify(client).deleteSession(FIRST_SESSION_ID);
+        verify(client, times(2)).createSession(anyString(), anyString(), anyString());
+        verify(applicationEventPublisher, times(2)).publishEvent(any(ConsulSessionCreatedEvent.class));
+    }
+
+    @Test
+    void createOrRenewSessionRetriesWhenPreviousSessionDeletionFails() {
+        when(client.createSession(anyString(), anyString(), anyString()))
+                .thenReturn(FIRST_SESSION_ID);
+        doThrow(new InvalidConsulSessionException(FIRST_SESSION_ID, new RuntimeException("not found")))
+                .when(client).renewSession(FIRST_SESSION_ID);
+        doThrow(new RuntimeException("delete failed")).when(client).deleteSession(FIRST_SESSION_ID);
+
+        consulService.createOrRenewSession();
+        consulService.createOrRenewSession();
+        consulService.createOrRenewSession();
+
+        assertNull(consulService.getActiveSessionId());
+        verify(client, times(1)).createSession(anyString(), anyString(), anyString());
+        verify(client, times(1)).deleteSession(FIRST_SESSION_ID);
+        verify(applicationEventPublisher, times(1)).publishEvent(any(ConsulSessionCreatedEvent.class));
+    }
+
+    @Test
+    void createOrRenewSessionClearsActiveSessionWhenRenewReturnsInvalidSession() {
+        when(client.createSession(anyString(), anyString(), anyString()))
+                .thenReturn(FIRST_SESSION_ID);
+        doThrow(new InvalidConsulSessionException(FIRST_SESSION_ID, new RuntimeException("not found")))
+                .when(client).renewSession(FIRST_SESSION_ID);
+
+        consulService.createOrRenewSession();
+        consulService.createOrRenewSession();
+
+        assertNull(consulService.getActiveSessionId());
+        verify(client).renewSession(FIRST_SESSION_ID);
+    }
+
+    @Test
+    void createOrRenewSessionKeepsActiveSessionWhenRenewFailsWithOtherError() {
+        when(client.createSession(anyString(), anyString(), anyString()))
+                .thenReturn(FIRST_SESSION_ID);
+        doThrow(new RuntimeException("renew failed")).when(client).renewSession(FIRST_SESSION_ID);
+
+        consulService.createOrRenewSession();
+        consulService.createOrRenewSession();
+
+        assertEquals(FIRST_SESSION_ID, consulService.getActiveSessionId());
+        verify(client).renewSession(FIRST_SESSION_ID);
+    }
+
+    @Test
+    void createOrRenewSessionKeepsActiveSessionNullWhenCreateFails() {
+        doThrow(new RuntimeException("create failed"))
+                .when(client).createSession(anyString(), anyString(), anyString());
+
+        consulService.createOrRenewSession();
+
+        assertNull(consulService.getActiveSessionId());
+        verify(applicationEventPublisher, never()).publishEvent(any());
+    }
+}

--- a/engine/src/test/java/org/qubership/integration/platform/engine/consul/InvalidConsulSessionExceptionTest.java
+++ b/engine/src/test/java/org/qubership/integration/platform/engine/consul/InvalidConsulSessionExceptionTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024-2025 NetCracker Technology Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.qubership.integration.platform.engine.consul;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class InvalidConsulSessionExceptionTest {
+
+    @Test
+    void exposesSessionIdInMessageAndPreservesCause() {
+        RuntimeException cause = new RuntimeException("not found");
+
+        InvalidConsulSessionException exception = new InvalidConsulSessionException("session-123", cause);
+
+        assertEquals("Consul session is invalid or expired: session-123", exception.getMessage());
+        assertSame(cause, exception.getCause());
+    }
+}


### PR DESCRIPTION
**Problem Description**
Engine pods register in Consul via a TTL session and an engines-state KV key locked with ?acquire=sessionId. On renew or delete failure, activeSessionId  was cleared and rotated to a new session while the previous session could remain valid on Consul. That left orphaned sessions and stale engines-state keys, so the catalog/UI showed more engines than running pods.

**Solution Description**
Fix Consul session error handling so failed renews no longer drop the active session and create orphans

- retain activeSessionId and retry with the same session ID.
- in case of (404)/session expired, rotate and create a new one.
- On delete failure, keep previousSessionId and retry. don't create a new session until cleanup succeeds.