### PR TITLE
fix(ui): hide secured variable in default secret when the flag is off #387

### DIFF
--- a/ui/src/components/admin_tools/variables/SecuredVariables.tsx
+++ b/ui/src/components/admin_tools/variables/SecuredVariables.tsx
@@ -138,8 +138,11 @@ export const SecuredVariables: React.FC = () => {
 
         sorted.forEach(
           ({ secretName, variables, isDefaultSecret, disabled }) => {
-            bySecret[secretName] = variables;
-            secretNames.push(secretName);
+            const isDisabledDefault = isDefaultSecret && disabled === true;
+            if (!isDisabledDefault) {
+              bySecret[secretName] = variables;
+              secretNames.push(secretName);
+            }
             if (isDefaultSecret) {
               defaultName = secretName;
               defaultRowDisabled = disabled === true;


### PR DESCRIPTION
Hides secured variabled in  default secret when the DEFAULT_SECRET_ENABLED=false