### PR TITLE
fix(runtime-catalog-0.5): implement fail-fast check for missing system IDs and map 404 and errror body

### DIFF
--- a/runtime-catalog/src/main/java/org/qubership/integration/platform/runtime/catalog/exception/GlobalExceptionHandler.java
+++ b/runtime-catalog/src/main/java/org/qubership/integration/platform/runtime/catalog/exception/GlobalExceptionHandler.java
@@ -74,8 +74,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     @ExceptionHandler(EntityNotFoundException.class)
-    public ResponseEntity<ExceptionDTO> handleEntityNotFound() {
-        return ResponseEntity.notFound().build();
+    public ResponseEntity<ExceptionDTO> handleEntityNotFound(EntityNotFoundException exception) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(getExceptionDTO(exception));
     }
 
     @ExceptionHandler(ChainExportException.class)

--- a/runtime-catalog/src/main/java/org/qubership/integration/platform/runtime/catalog/service/ContextBaseService.java
+++ b/runtime-catalog/src/main/java/org/qubership/integration/platform/runtime/catalog/service/ContextBaseService.java
@@ -16,6 +16,7 @@
 
 package org.qubership.integration.platform.runtime.catalog.service;
 
+import jakarta.persistence.EntityNotFoundException;
 import org.qubership.integration.platform.runtime.catalog.model.constant.CamelOptions;
 import org.qubership.integration.platform.runtime.catalog.persistence.configs.entity.actionlog.ActionLog;
 import org.qubership.integration.platform.runtime.catalog.persistence.configs.entity.actionlog.EntityType;
@@ -33,6 +34,8 @@ import java.util.*;
 
 @Service
 public class ContextBaseService {
+
+    private static final String CONTEXT_SYSTEM_WITH_ID_NOT_FOUND = "Can't find context system with id: ";
 
     protected final ContextSystemRepository contextSystemRepository;
     protected final ActionsLogService actionsLogger;
@@ -94,7 +97,8 @@ public class ContextBaseService {
 
     @Transactional
     public void delete(String systemId) {
-        ContextSystem system = contextSystemRepository.getReferenceById(systemId);
+        ContextSystem system = contextSystemRepository.findById(systemId)
+            .orElseThrow(() -> new EntityNotFoundException(CONTEXT_SYSTEM_WITH_ID_NOT_FOUND + systemId));
         contextSystemRepository.delete(system);
         logSystemAction(system, LogOperation.DELETE);
     }

--- a/runtime-catalog/src/main/java/org/qubership/integration/platform/runtime/catalog/service/SystemBaseService.java
+++ b/runtime-catalog/src/main/java/org/qubership/integration/platform/runtime/catalog/service/SystemBaseService.java
@@ -16,6 +16,7 @@
 
 package org.qubership.integration.platform.runtime.catalog.service;
 
+import jakarta.persistence.EntityNotFoundException;
 import org.qubership.integration.platform.runtime.catalog.model.system.IntegrationSystemType;
 import org.qubership.integration.platform.runtime.catalog.model.system.OperationProtocol;
 import org.qubership.integration.platform.runtime.catalog.persistence.configs.entity.actionlog.ActionLog;
@@ -36,6 +37,8 @@ import static java.util.Objects.isNull;
 
 @Service
 public class SystemBaseService {
+
+    private static final String SYSTEM_WITH_ID_NOT_FOUND = "Can't find system with id: ";
 
     private static final Map<IntegrationSystemType, Collection<OperationProtocol>> ALLOWED_PROTOCOL_MAP = Map.of(
             IntegrationSystemType.EXTERNAL, Arrays.stream(OperationProtocol.values())
@@ -110,7 +113,8 @@ public class SystemBaseService {
 
     @Transactional
     public void delete(String systemId) {
-        IntegrationSystem system = systemRepository.getReferenceById(systemId);
+        IntegrationSystem system = systemRepository.findById(systemId)
+                .orElseThrow(() -> new EntityNotFoundException(SYSTEM_WITH_ID_NOT_FOUND + systemId));
         systemRepository.delete(system);
         logSystemAction(system, LogOperation.DELETE);
     }


### PR DESCRIPTION
Fixes a generic 500 Internal Server Error when trying to delete a non-existent System ID.

- Replaced a lazy proxy reference check with a fail-fast findById().orElseThrow() validation block to catch missing IDs early before hitting the deletion utility.
- Updated @ExceptionHandler(EntityNotFoundException.class) to accept the exception and map it directly into the standard ExceptionDTO instead of returning an empty 404 response.