### PR TITLE
fix(micro-engine): Fix orphaned Consul sessions causing stale engines…

### DIFF
--- a/micro-engine/src/main/java/org/qubership/integration/platform/engine/consul/ConsulOperationTimeoutException.java
+++ b/micro-engine/src/main/java/org/qubership/integration/platform/engine/consul/ConsulOperationTimeoutException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024-2025 NetCracker Technology Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.qubership.integration.platform.engine.consul;
+
+public class ConsulOperationTimeoutException extends RuntimeException {
+    public ConsulOperationTimeoutException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/micro-engine/src/main/java/org/qubership/integration/platform/engine/consul/ConsulSessionService.java
+++ b/micro-engine/src/main/java/org/qubership/integration/platform/engine/consul/ConsulSessionService.java
@@ -1,6 +1,7 @@
 package org.qubership.integration.platform.engine.consul;
 
 import io.quarkus.scheduler.Scheduled;
+import io.smallrye.mutiny.TimeoutException;
 import io.smallrye.mutiny.Uni;
 import io.vertx.ext.consul.SessionBehavior;
 import io.vertx.ext.consul.SessionOptions;
@@ -9,7 +10,9 @@ import io.vertx.mutiny.ext.consul.ConsulClient;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
+import java.time.Duration;
 import java.util.UUID;
 import java.util.function.Supplier;
 
@@ -25,6 +28,13 @@ public class ConsulSessionService {
     private static final String SESSION_PREFIX = "qip-engine-session-";
     private static final SessionBehavior SESSION_BEHAVIOR = SessionBehavior.DELETE;
     private static final long SESSION_TTL = 60;
+    private static final long CONSUL_AWAIT_BUFFER_MS = 1_000;
+
+    @ConfigProperty(name = "consul.connectTimeout")
+    int consulConnectTimeout;
+
+    @ConfigProperty(name = "consul.timeout")
+    int consulTimeout;
 
     @Inject
     Supplier<ConsulClient> consulClientSupplier;
@@ -40,6 +50,10 @@ public class ConsulSessionService {
             doCreateOrRenewSession();
         }
         return sessionId;
+    }
+
+    public Duration getAwaitTimeout() {
+        return consulAwaitTimeout();
     }
 
     @Scheduled(
@@ -68,11 +82,17 @@ public class ConsulSessionService {
             log.warn("Consul session expired, scheduling destroy and creating a new one: {}", sessionId);
             previousSessionId = sessionId;
             sessionId = null;
+        } catch (ConsulOperationTimeoutException e) {
+            if (nonNull(sessionId)) {
+                log.warn("Consul session renew timed out, will retry with the same session id: {}", sessionId);
+            } else {
+                log.error("Consul session creation timed out. Consul agent might be unreachable.", e);
+            }
         } catch (Exception e) {
             if (nonNull(sessionId)) {
-                log.warn("Failed to renew consul session, will retry with the same session id", e);
+                log.warn("Failed to renew consul session due to unexpected error, will retry with the same session id", e);
             } else {
-                log.error("Failed to create consul session", e);
+                log.error("Failed to create consul session due to unexpected error", e);
             }
         }
     }
@@ -98,37 +118,29 @@ public class ConsulSessionService {
     }
 
     private void renewSession(String id) {
-        consulClientSupplier.get().renewSession(id)
-                .onFailure()
-                .transform(failure -> {
-                    if (sessionNotFoundError(failure)) {
-                        return new InvalidConsulSessionException(id, failure);
-                    }
+        awaitConsul(consulClientSupplier.get().renewSession(id)
+            .onFailure().invoke(failure -> {
+                if (!sessionNotFoundError(failure)) {
                     log.error("Failed to renew session in consul: {}", failure.getMessage());
-                    return failure;
-                })
-                .await()
-                .indefinitely();
+                }
+            })
+            .onFailure(this::sessionNotFoundError).transform(failure -> new InvalidConsulSessionException(id, failure))
+        );
     }
 
     private String createSession() {
         String name = SESSION_PREFIX + UUID.randomUUID();
         SessionOptions options = new SessionOptions()
-                .setName(name)
-                .setTtl(SESSION_TTL)
-                .setBehavior(SESSION_BEHAVIOR);
-        return consulClientSupplier.get().createSessionWithOptions(options)
-                .onFailure()
-                .transform(failure -> {
-                    log.error("Failed to create session in consul: {}", failure.getMessage());
-                    return failure;
-                })
-                .await()
-                .indefinitely();
+            .setName(name)
+            .setTtl(SESSION_TTL)
+            .setBehavior(SESSION_BEHAVIOR);
+        return awaitConsul(consulClientSupplier.get().createSessionWithOptions(options)
+            .onFailure().invoke(failure -> log.error("Failed to create session in consul: {}", failure.getMessage()))
+        );
     }
 
     private void deleteSession(String id) {
-        consulClientSupplier.get().destroySession(id)
+        awaitConsul(consulClientSupplier.get().destroySession(id)
                 .onFailure()
                 .recoverWithUni(failure -> {
                     if (sessionNotFoundError(failure)) {
@@ -137,9 +149,21 @@ public class ConsulSessionService {
                     }
                     log.error("Failed to delete session from consul: {}", failure.getMessage());
                     return Uni.createFrom().failure(failure);
-                })
-                .await()
-                .indefinitely();
+                }));
+    }
+
+    private <T> T awaitConsul(Uni<T> uni) {
+        try {
+            return uni.await().atMost(consulAwaitTimeout());
+        } catch (TimeoutException e) {
+            throw new ConsulOperationTimeoutException(
+                "Consul operation exceeded safety threshold of " + consulAwaitTimeout().toMillis() + "ms", e
+            );
+        }
+    }
+
+    private Duration consulAwaitTimeout() {
+        return Duration.ofMillis((long) consulConnectTimeout + consulTimeout + CONSUL_AWAIT_BUFFER_MS);
     }
 
     private boolean sessionNotFoundError(Throwable e) {

--- a/micro-engine/src/main/java/org/qubership/integration/platform/engine/consul/ConsulSessionService.java
+++ b/micro-engine/src/main/java/org/qubership/integration/platform/engine/consul/ConsulSessionService.java
@@ -167,6 +167,12 @@ public class ConsulSessionService {
     }
 
     private boolean sessionNotFoundError(Throwable e) {
-        return e.getMessage() != null && e.getMessage().matches("Session id .* not found");
+        for (Throwable current = e; current != null; current = current.getCause()) {
+            String message = current.getMessage();
+            if (message != null && message.contains("Session id") && message.contains("not found")) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/micro-engine/src/main/java/org/qubership/integration/platform/engine/consul/ConsulSessionService.java
+++ b/micro-engine/src/main/java/org/qubership/integration/platform/engine/consul/ConsulSessionService.java
@@ -1,6 +1,7 @@
 package org.qubership.integration.platform.engine.consul;
 
 import io.quarkus.scheduler.Scheduled;
+import io.smallrye.mutiny.Uni;
 import io.vertx.ext.consul.SessionBehavior;
 import io.vertx.ext.consul.SessionOptions;
 import io.vertx.mutiny.core.eventbus.EventBus;
@@ -52,10 +53,8 @@ public class ConsulSessionService {
     private synchronized void doCreateOrRenewSession() {
         try {
             if (isNull(sessionId)) {
-                if (nonNull(previousSessionId)) {
-                    log.info("Delete old consul session: {}", previousSessionId);
-                    deleteSession(previousSessionId);
-                    previousSessionId = null;
+                if (nonNull(previousSessionId) && !deletePreviousSession()) {
+                    return;
                 }
                 log.debug("Create consul session");
                 sessionId = createSession();
@@ -65,10 +64,32 @@ public class ConsulSessionService {
                 log.debug("Renew consul session");
                 renewSession(sessionId);
             }
-        } catch (Exception e) {
-            log.error("Failed to create/renew consul session", e);
-            previousSessionId = sessionNotFoundError(e) ? null : sessionId;
+        } catch (InvalidConsulSessionException e) {
+            log.warn("Consul session expired, scheduling destroy and creating a new one: {}", sessionId);
+            previousSessionId = sessionId;
             sessionId = null;
+        } catch (Exception e) {
+            if (nonNull(sessionId)) {
+                log.warn("Failed to renew consul session, will retry with the same session id", e);
+            } else {
+                log.error("Failed to create consul session", e);
+            }
+        }
+    }
+
+    private boolean deletePreviousSession() {
+        if (isNull(previousSessionId)) {
+            return true;
+        }
+
+        try {
+            log.info("Delete old consul session: {}", previousSessionId);
+            deleteSession(previousSessionId);
+            previousSessionId = null;
+            return true;
+        } catch (Exception e) {
+            log.warn("Failed to delete previous consul session {}, will retry", previousSessionId, e);
+            return false;
         }
     }
 
@@ -80,6 +101,9 @@ public class ConsulSessionService {
         consulClientSupplier.get().renewSession(id)
                 .onFailure()
                 .transform(failure -> {
+                    if (sessionNotFoundError(failure)) {
+                        return new InvalidConsulSessionException(id, failure);
+                    }
                     log.error("Failed to renew session in consul: {}", failure.getMessage());
                     return failure;
                 })
@@ -104,13 +128,21 @@ public class ConsulSessionService {
     }
 
     private void deleteSession(String id) {
-        consulClientSupplier.get().destroySession(id).onFailure().transform(failure -> {
-            log.error("Failed to delete session from consul: {}", failure.getMessage());
-            return failure;
-        }).await().indefinitely();
+        consulClientSupplier.get().destroySession(id)
+                .onFailure()
+                .recoverWithUni(failure -> {
+                    if (sessionNotFoundError(failure)) {
+                        log.debug("Consul session already gone: {}", id);
+                        return Uni.createFrom().voidItem();
+                    }
+                    log.error("Failed to delete session from consul: {}", failure.getMessage());
+                    return Uni.createFrom().failure(failure);
+                })
+                .await()
+                .indefinitely();
     }
 
-    private boolean sessionNotFoundError(Exception e) {
-        return e.getMessage().matches("Session id .* not found");
+    private boolean sessionNotFoundError(Throwable e) {
+        return e.getMessage() != null && e.getMessage().matches("Session id .* not found");
     }
 }

--- a/micro-engine/src/main/java/org/qubership/integration/platform/engine/consul/InvalidConsulSessionException.java
+++ b/micro-engine/src/main/java/org/qubership/integration/platform/engine/consul/InvalidConsulSessionException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024-2025 NetCracker Technology Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.qubership.integration.platform.engine.consul;
+
+public class InvalidConsulSessionException extends RuntimeException {
+    public InvalidConsulSessionException(String sessionId, Throwable cause) {
+        super("Consul session is invalid or expired: " + sessionId, cause);
+    }
+}

--- a/micro-engine/src/main/java/org/qubership/integration/platform/engine/state/EngineStateService.java
+++ b/micro-engine/src/main/java/org/qubership/integration/platform/engine/state/EngineStateService.java
@@ -3,6 +3,7 @@ package org.qubership.integration.platform.engine.state;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.smallrye.common.annotation.Identifier;
+import io.smallrye.mutiny.TimeoutException;
 import io.vertx.ext.consul.KeyValueOptions;
 import io.vertx.mutiny.ext.consul.ConsulClient;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -14,6 +15,7 @@ import org.qubership.integration.platform.engine.consul.ConsulSessionService;
 import org.qubership.integration.platform.engine.model.engine.EngineInfo;
 import org.qubership.integration.platform.engine.model.engine.EngineState;
 
+import java.time.Duration;
 import java.util.UUID;
 import java.util.function.Supplier;
 
@@ -76,17 +78,20 @@ public class EngineStateService {
                 .setAcquireSession(sessionId);
         try {
             String value = objectMapper.writeValueAsString(state);
+            Duration timeout = consulSessionService.getAwaitTimeout();
             consulClientSupplier.get().putValueWithOptions(key, value, options)
-                    .onFailure()
-                    .transform(failure -> {
-                        log.error("Failed to create or update KV in consul: {}", failure.getMessage());
-                        return failure;
-                    })
+                    .onFailure().invoke(failure -> log.error("Failed to create or update KV in consul: {}", failure.getMessage()))
                     .await()
-                    .indefinitely();
+                    .atMost(timeout);
         } catch (JsonProcessingException e) {
-            log.error("Failed to serialize value: {}", e.getMessage());
+            log.error("Failed to serialize value: {}", e.getMessage(), e);
             throw new RuntimeException(e);
+        } catch (TimeoutException e) {
+            log.error("Timeout while creating or updating KV in consul for key: {}", key, e);
+            throw e;
+        } catch (Exception e) {
+            log.error("Unexpected error updating engine state in Consul KV for key: {}", key, e);
+            throw e;
         }
     }
 }

--- a/micro-engine/src/test/java/org/qubership/integration/platform/engine/consul/ConsulSessionServiceTest.java
+++ b/micro-engine/src/test/java/org/qubership/integration/platform/engine/consul/ConsulSessionServiceTest.java
@@ -15,7 +15,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.qubership.integration.platform.engine.testutils.DisplayNameUtils;
 
+import java.lang.reflect.Method;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -147,5 +150,118 @@ class ConsulSessionServiceTest {
 
         assertNull(result);
         verify(eventBus, never()).publish(anyString(), any());
+    }
+
+    @Test
+    void shouldNotCreateNewSessionWhenPreviousSessionDeleteFails() {
+        when(consulClient.createSessionWithOptions(any(SessionOptions.class)))
+                .thenReturn(Uni.createFrom().item(FIRST_SESSION_ID));
+        when(consulClient.renewSession(FIRST_SESSION_ID))
+                .thenReturn(Uni.createFrom().failure(
+                        new RuntimeException("Session id " + FIRST_SESSION_ID + " not found")));
+        when(consulClient.destroySession(FIRST_SESSION_ID))
+                .thenReturn(Uni.createFrom().failure(new RuntimeException("Consul unavailable")));
+
+        service.getOrCreateSession();
+        service.createOrRenewSession();
+
+        assertNull(service.getOrCreateSession());
+        service.createOrRenewSession();
+
+        verify(consulClient, times(1)).createSessionWithOptions(any(SessionOptions.class));
+        verify(consulClient, times(2)).destroySession(FIRST_SESSION_ID);
+        verify(eventBus, times(1)).publish(ConsulSessionService.CREATE_SESSION_EVENT, FIRST_SESSION_ID);
+    }
+
+    @Test
+    void shouldKeepSessionWhenRenewFailsWithNonSessionNotFoundError() {
+        when(consulClient.createSessionWithOptions(any(SessionOptions.class)))
+                .thenReturn(Uni.createFrom().item(FIRST_SESSION_ID));
+        when(consulClient.renewSession(FIRST_SESSION_ID))
+                .thenReturn(Uni.createFrom().failure(new RuntimeException("network error")));
+
+        service.getOrCreateSession();
+        service.createOrRenewSession();
+
+        assertEquals(FIRST_SESSION_ID, service.getOrCreateSession());
+        verify(consulClient, times(1)).createSessionWithOptions(any(SessionOptions.class));
+        verify(consulClient, never()).destroySession(anyString());
+        verify(eventBus, times(1)).publish(ConsulSessionService.CREATE_SESSION_EVENT, FIRST_SESSION_ID);
+    }
+
+    @Test
+    void shouldCompleteRecoveryWhenDestroyFindsSessionAlreadyGone() {
+        when(consulClient.createSessionWithOptions(any(SessionOptions.class)))
+                .thenReturn(
+                        Uni.createFrom().item(FIRST_SESSION_ID),
+                        Uni.createFrom().item(SECOND_SESSION_ID)
+                );
+        when(consulClient.renewSession(FIRST_SESSION_ID))
+                .thenReturn(Uni.createFrom().failure(
+                        new RuntimeException("Session id " + FIRST_SESSION_ID + " not found")));
+        when(consulClient.destroySession(FIRST_SESSION_ID))
+                .thenReturn(Uni.createFrom().failure(
+                        new RuntimeException("Session id " + FIRST_SESSION_ID + " not found")));
+
+        service.getOrCreateSession();
+        service.createOrRenewSession();
+        String result = service.getOrCreateSession();
+
+        assertEquals(SECOND_SESSION_ID, result);
+        verify(consulClient).destroySession(FIRST_SESSION_ID);
+        verify(eventBus).publish(ConsulSessionService.CREATE_SESSION_EVENT, FIRST_SESSION_ID);
+        verify(eventBus).publish(ConsulSessionService.CREATE_SESSION_EVENT, SECOND_SESSION_ID);
+    }
+
+    @Test
+    void shouldCreateNewSessionAfterPreviousSessionDeleteEventuallySucceeds() {
+        when(consulClient.createSessionWithOptions(any(SessionOptions.class)))
+                .thenReturn(
+                        Uni.createFrom().item(FIRST_SESSION_ID),
+                        Uni.createFrom().item(SECOND_SESSION_ID)
+                );
+        when(consulClient.renewSession(FIRST_SESSION_ID))
+                .thenReturn(Uni.createFrom().failure(
+                        new RuntimeException("Session id " + FIRST_SESSION_ID + " not found")));
+        when(consulClient.destroySession(FIRST_SESSION_ID))
+                .thenReturn(
+                        Uni.createFrom().failure(new RuntimeException("Consul unavailable")),
+                        Uni.createFrom().voidItem()
+                );
+
+        service.getOrCreateSession();
+        service.createOrRenewSession();
+
+        assertNull(service.getOrCreateSession());
+        String result = service.getOrCreateSession();
+
+        assertEquals(SECOND_SESSION_ID, result);
+        verify(consulClient, times(2)).destroySession(FIRST_SESSION_ID);
+        verify(consulClient, times(2)).createSessionWithOptions(any(SessionOptions.class));
+        verify(eventBus).publish(ConsulSessionService.CREATE_SESSION_EVENT, FIRST_SESSION_ID);
+        verify(eventBus).publish(ConsulSessionService.CREATE_SESSION_EVENT, SECOND_SESSION_ID);
+    }
+
+    @Test
+    void shouldReturnTrueWhenDeletePreviousSessionCalledWithNoPreviousSession() throws Exception {
+        Method deletePreviousSession = ConsulSessionService.class.getDeclaredMethod("deletePreviousSession");
+        deletePreviousSession.setAccessible(true);
+
+        boolean result = (boolean) deletePreviousSession.invoke(service);
+
+        assertTrue(result);
+        verify(consulClient, never()).destroySession(anyString());
+    }
+
+    @Test
+    void shouldDetectSessionNotFoundErrorOnlyForMatchingMessage() throws Exception {
+        Method sessionNotFoundError = ConsulSessionService.class.getDeclaredMethod(
+                "sessionNotFoundError", Throwable.class);
+        sessionNotFoundError.setAccessible(true);
+
+        assertFalse((boolean) sessionNotFoundError.invoke(service, new RuntimeException((String) null)));
+        assertFalse((boolean) sessionNotFoundError.invoke(service, new RuntimeException("network error")));
+        assertTrue((boolean) sessionNotFoundError.invoke(service,
+                new RuntimeException("Session id " + FIRST_SESSION_ID + " not found")));
     }
 }

--- a/micro-engine/src/test/java/org/qubership/integration/platform/engine/consul/ConsulSessionServiceTest.java
+++ b/micro-engine/src/test/java/org/qubership/integration/platform/engine/consul/ConsulSessionServiceTest.java
@@ -15,11 +15,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.qubership.integration.platform.engine.testutils.DisplayNameUtils;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -34,6 +36,7 @@ class ConsulSessionServiceTest {
 
     private static final String FIRST_SESSION_ID = "8d4d10b6-9b8c-4ad0-a133-fb85cf9d2865";
     private static final String SECOND_SESSION_ID = "f7f1e7e1-6f8d-4f6e-b74c-d6f0af3df482";
+    private static final int SHORT_CONSUL_TIMEOUT_MS = 10;
 
     private ConsulSessionService service;
 
@@ -47,6 +50,8 @@ class ConsulSessionServiceTest {
         service = new ConsulSessionService();
         service.consulClientSupplier = () -> consulClient;
         service.eventBus = eventBus;
+        service.consulConnectTimeout = 25_000;
+        service.consulTimeout = 25_000;
     }
 
     @Test
@@ -254,6 +259,41 @@ class ConsulSessionServiceTest {
     }
 
     @Test
+    void testCreateSessionTimeoutBehavior() throws Exception {
+        useShortConsulAwaitTimeout();
+        when(consulClient.createSessionWithOptions(any(SessionOptions.class)))
+                .thenReturn(Uni.createFrom().nothing());
+
+        Method awaitConsul = ConsulSessionService.class.getDeclaredMethod("awaitConsul", Uni.class);
+        awaitConsul.setAccessible(true);
+        assertThrows(ConsulOperationTimeoutException.class,
+                () -> invokeReflective(awaitConsul, service, Uni.createFrom().nothing()));
+
+        assertNull(service.getOrCreateSession());
+        verify(eventBus, never()).publish(anyString(), any());
+    }
+
+    @Test
+    void testRenewSessionTimeoutBehavior() throws Exception {
+        useShortConsulAwaitTimeout();
+        when(consulClient.createSessionWithOptions(any(SessionOptions.class)))
+                .thenReturn(Uni.createFrom().item(FIRST_SESSION_ID));
+        when(consulClient.renewSession(FIRST_SESSION_ID))
+                .thenReturn(Uni.createFrom().nothing());
+
+        service.getOrCreateSession();
+
+        Method renewSession = ConsulSessionService.class.getDeclaredMethod("renewSession", String.class);
+        renewSession.setAccessible(true);
+        assertThrows(ConsulOperationTimeoutException.class,
+                () -> invokeReflective(renewSession, service, FIRST_SESSION_ID));
+
+        service.createOrRenewSession();
+
+        assertEquals(FIRST_SESSION_ID, service.getOrCreateSession());
+    }
+
+    @Test
     void shouldDetectSessionNotFoundErrorOnlyForMatchingMessage() throws Exception {
         Method sessionNotFoundError = ConsulSessionService.class.getDeclaredMethod(
                 "sessionNotFoundError", Throwable.class);
@@ -263,5 +303,18 @@ class ConsulSessionServiceTest {
         assertFalse((boolean) sessionNotFoundError.invoke(service, new RuntimeException("network error")));
         assertTrue((boolean) sessionNotFoundError.invoke(service,
                 new RuntimeException("Session id " + FIRST_SESSION_ID + " not found")));
+    }
+
+    private void useShortConsulAwaitTimeout() {
+        service.consulConnectTimeout = SHORT_CONSUL_TIMEOUT_MS;
+        service.consulTimeout = SHORT_CONSUL_TIMEOUT_MS;
+    }
+
+    private static void invokeReflective(Method method, Object target, Object... args) throws Throwable {
+        try {
+            method.invoke(target, args);
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
+        }
     }
 }

--- a/micro-engine/src/test/java/org/qubership/integration/platform/engine/consul/ConsulSessionServiceTest.java
+++ b/micro-engine/src/test/java/org/qubership/integration/platform/engine/consul/ConsulSessionServiceTest.java
@@ -147,6 +147,26 @@ class ConsulSessionServiceTest {
     }
 
     @Test
+    void shouldAttemptToDestroyPreviousSessionWhenRenewFailsWithVertxSessionNotFoundMessage() {
+        when(consulClient.createSessionWithOptions(any(SessionOptions.class)))
+                .thenReturn(
+                        Uni.createFrom().item(FIRST_SESSION_ID),
+                        Uni.createFrom().item(SECOND_SESSION_ID)
+                );
+        when(consulClient.renewSession(FIRST_SESSION_ID))
+                .thenReturn(Uni.createFrom().failure(vertxSessionNotFoundError(FIRST_SESSION_ID)));
+
+        service.getOrCreateSession();
+        service.createOrRenewSession();
+        String result = service.getOrCreateSession();
+
+        assertEquals(SECOND_SESSION_ID, result);
+        verify(consulClient, times(1)).destroySession(anyString());
+        verify(eventBus).publish(ConsulSessionService.CREATE_SESSION_EVENT, FIRST_SESSION_ID);
+        verify(eventBus).publish(ConsulSessionService.CREATE_SESSION_EVENT, SECOND_SESSION_ID);
+    }
+
+    @Test
     void shouldReturnNullWhenCreateSessionFails() {
         when(consulClient.createSessionWithOptions(any(SessionOptions.class)))
                 .thenReturn(Uni.createFrom().failure(new RuntimeException("Create failed")));
@@ -303,6 +323,12 @@ class ConsulSessionServiceTest {
         assertFalse((boolean) sessionNotFoundError.invoke(service, new RuntimeException("network error")));
         assertTrue((boolean) sessionNotFoundError.invoke(service,
                 new RuntimeException("Session id " + FIRST_SESSION_ID + " not found")));
+        assertTrue((boolean) sessionNotFoundError.invoke(service, vertxSessionNotFoundError(FIRST_SESSION_ID)));
+    }
+
+    private static RuntimeException vertxSessionNotFoundError(String sessionId) {
+        return new RuntimeException(
+                "Status message: 'Not Found'. Body: 'Session id '" + sessionId + "' not found' ");
     }
 
     private void useShortConsulAwaitTimeout() {

--- a/micro-engine/src/test/java/org/qubership/integration/platform/engine/consul/ConsulSessionServiceTest.java
+++ b/micro-engine/src/test/java/org/qubership/integration/platform/engine/consul/ConsulSessionServiceTest.java
@@ -102,7 +102,7 @@ class ConsulSessionServiceTest {
                         Uni.createFrom().item(SECOND_SESSION_ID)
                 );
         when(consulClient.renewSession(FIRST_SESSION_ID))
-                .thenReturn(Uni.createFrom().failure(new RuntimeException("Renew failed")));
+                .thenReturn(Uni.createFrom().failure(new RuntimeException("Session id " + FIRST_SESSION_ID + " not found")));
         when(consulClient.destroySession(FIRST_SESSION_ID))
                 .thenReturn(Uni.createFrom().voidItem());
 
@@ -117,7 +117,7 @@ class ConsulSessionServiceTest {
     }
 
     @Test
-    void shouldCreateNewSessionWithoutDeletingPreviousWhenRenewFailsWithSessionNotFoundMessage() {
+    void shouldAttemptToDestroyPreviousSessionWhenRenewFailsWithSessionNotFoundMessage() {
         when(consulClient.createSessionWithOptions(any(SessionOptions.class)))
                 .thenReturn(
                         Uni.createFrom().item(FIRST_SESSION_ID),
@@ -133,7 +133,7 @@ class ConsulSessionServiceTest {
         String result = service.getOrCreateSession();
 
         assertEquals(SECOND_SESSION_ID, result);
-        verify(consulClient, never()).destroySession(anyString());
+        verify(consulClient, times(1)).destroySession(anyString());
         verify(eventBus).publish(ConsulSessionService.CREATE_SESSION_EVENT, FIRST_SESSION_ID);
         verify(eventBus).publish(ConsulSessionService.CREATE_SESSION_EVENT, SECOND_SESSION_ID);
     }

--- a/micro-engine/src/test/java/org/qubership/integration/platform/engine/consul/EngineStateServiceTest.java
+++ b/micro-engine/src/test/java/org/qubership/integration/platform/engine/consul/EngineStateServiceTest.java
@@ -19,6 +19,7 @@ import org.qubership.integration.platform.engine.model.engine.EngineState;
 import org.qubership.integration.platform.engine.state.EngineStateService;
 import org.qubership.integration.platform.engine.testutils.DisplayNameUtils;
 
+import java.time.Duration;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
@@ -71,10 +72,8 @@ class EngineStateServiceTest {
     void shouldPutSerializedStateToConsulWhenSessionPresentAndDynamicKeysDisabled() throws Exception {
         EngineState state = new EngineState();
 
-        when(consulSessionService.getOrCreateSession()).thenReturn(SESSION_ID);
-        when(engineInfo.getEngineDeploymentName()).thenReturn("engine-deployment");
-        when(engineInfo.getDomain()).thenReturn("customer-domain");
-        when(engineInfo.getHost()).thenReturn("host.example.com");
+        stubConsulSessionForKvWrite();
+        stubEngineInfo();
         when(objectMapper.writeValueAsString(state)).thenReturn("serialized-state");
         when(consulClient.putValueWithOptions(
                 eq("config/test/qip-engine-configurations/engines-state/engine-deployment-customer-domain-host_example_com"),
@@ -99,10 +98,8 @@ class EngineStateServiceTest {
     void shouldAppendLocalNodeIdToConsulKeyWhenDynamicStateKeysEnabled() throws Exception {
         EngineState state = new EngineState();
 
-        when(consulSessionService.getOrCreateSession()).thenReturn(SESSION_ID);
-        when(engineInfo.getEngineDeploymentName()).thenReturn("engine-deployment");
-        when(engineInfo.getDomain()).thenReturn("customer-domain");
-        when(engineInfo.getHost()).thenReturn("host.example.com");
+        stubConsulSessionForKvWrite();
+        stubEngineInfo();
         when(objectMapper.writeValueAsString(state)).thenReturn("serialized-state");
         when(consulClient.putValueWithOptions(
                 any(),
@@ -149,9 +146,7 @@ class EngineStateServiceTest {
         };
 
         when(consulSessionService.getOrCreateSession()).thenReturn(SESSION_ID);
-        when(engineInfo.getEngineDeploymentName()).thenReturn("engine-deployment");
-        when(engineInfo.getDomain()).thenReturn("customer-domain");
-        when(engineInfo.getHost()).thenReturn("host.example.com");
+        stubEngineInfo();
         when(objectMapper.writeValueAsString(state)).thenThrow(cause);
 
         RuntimeException exception = assertThrows(
@@ -161,5 +156,24 @@ class EngineStateServiceTest {
 
         assertSame(cause, exception.getCause());
         verify(consulClient, never()).putValueWithOptions(any(), any(), any());
+    }
+
+    private void stubConsulSession() {
+        when(consulSessionService.getOrCreateSession()).thenReturn(SESSION_ID);
+    }
+
+    private void stubConsulKvTimeout() {
+        when(consulSessionService.getAwaitTimeout()).thenReturn(Duration.ofSeconds(51));
+    }
+
+    private void stubConsulSessionForKvWrite() {
+        stubConsulSession();
+        stubConsulKvTimeout();
+    }
+
+    private void stubEngineInfo() {
+        when(engineInfo.getEngineDeploymentName()).thenReturn("engine-deployment");
+        when(engineInfo.getDomain()).thenReturn("customer-domain");
+        when(engineInfo.getHost()).thenReturn("host.example.com");
     }
 }

--- a/micro-engine/src/test/java/org/qubership/integration/platform/engine/state/EngineStateServiceTest.java
+++ b/micro-engine/src/test/java/org/qubership/integration/platform/engine/state/EngineStateServiceTest.java
@@ -2,6 +2,7 @@ package org.qubership.integration.platform.engine.state;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.smallrye.mutiny.TimeoutException;
 import io.smallrye.mutiny.Uni;
 import io.vertx.ext.consul.KeyValueOptions;
 import io.vertx.mutiny.ext.consul.ConsulClient;
@@ -18,6 +19,7 @@ import org.qubership.integration.platform.engine.model.engine.EngineInfo;
 import org.qubership.integration.platform.engine.model.engine.EngineState;
 import org.qubership.integration.platform.engine.testutils.DisplayNameUtils;
 
+import java.time.Duration;
 import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -87,7 +89,7 @@ class EngineStateServiceTest {
 
     @Test
     void shouldUpdateEngineStateInConsulWithAcquiredSession() throws Exception {
-        stubConsulSession();
+        stubConsulSessionForKvWrite();
         stubEngineInfo();
         when(consulKeyValidator.makeKeyValid("qip-engine-v1-default-localhost")).thenReturn(VALID_ENGINE_KEY);
         when(objectMapper.writeValueAsString(state)).thenReturn(SERIALIZED_STATE);
@@ -109,7 +111,7 @@ class EngineStateServiceTest {
     void shouldBuildDynamicConsulKeyWhenDynamicStateKeysAreEnabled() throws Exception {
         service.dynamicStateKeys = true;
 
-        stubConsulSession();
+        stubConsulSessionForKvWrite();
         stubEngineInfo();
         when(consulKeyValidator.makeKeyValid(anyString())).thenReturn("valid-dynamic-engine-key");
         when(objectMapper.writeValueAsString(state)).thenReturn(SERIALIZED_STATE);
@@ -147,10 +149,29 @@ class EngineStateServiceTest {
     }
 
     @Test
+    void shouldThrowTimeoutExceptionWhenKvWriteStalls() throws Exception {
+        stubConsulSession();
+        stubEngineInfo();
+        when(consulSessionService.getAwaitTimeout()).thenReturn(Duration.ofMillis(100));
+        when(consulKeyValidator.makeKeyValid("qip-engine-v1-default-localhost")).thenReturn(VALID_ENGINE_KEY);
+        when(objectMapper.writeValueAsString(org.mockito.ArgumentMatchers.any(EngineState.class)))
+                .thenReturn(SERIALIZED_STATE);
+        when(consulClientSupplier.get()).thenReturn(consulClient);
+        when(consulClient.putValueWithOptions(
+                eq("qip/engine-config/engines-state/" + VALID_ENGINE_KEY),
+                eq(SERIALIZED_STATE),
+                org.mockito.ArgumentMatchers.any(KeyValueOptions.class)
+        )).thenReturn(Uni.createFrom().nothing());
+
+        EngineState engineState = new EngineState();
+        assertThrows(TimeoutException.class, () -> service.updateState(engineState));
+    }
+
+    @Test
     void shouldPropagateConsulFailureWhenPutValueFails() throws Exception {
         IllegalStateException consulException = new IllegalStateException("Consul write failed");
 
-        stubConsulSession();
+        stubConsulSessionForKvWrite();
         stubEngineInfo();
         when(consulKeyValidator.makeKeyValid("qip-engine-v1-default-localhost")).thenReturn(VALID_ENGINE_KEY);
         when(objectMapper.writeValueAsString(state)).thenReturn(SERIALIZED_STATE);
@@ -168,6 +189,15 @@ class EngineStateServiceTest {
 
     private void stubConsulSession() {
         when(consulSessionService.getOrCreateSession()).thenReturn(SESSION_ID);
+    }
+
+    private void stubConsulKvTimeout() {
+        when(consulSessionService.getAwaitTimeout()).thenReturn(Duration.ofSeconds(51));
+    }
+
+    private void stubConsulSessionForKvWrite() {
+        stubConsulSession();
+        stubConsulKvTimeout();
     }
 
     private void stubEngineInfo() {


### PR DESCRIPTION
…-state keys #277

- Port Consul session recovery to ConsulSessionService
- Detect expired sessions on renew,
- Retry transient renew failures with the same session id
- And treat already-destroyed sessions as a successful delete before creating a new session.