### PR TITLE
fix(engine): add mockito-junit-jupiter for Consul unit tests

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -334,6 +334,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>de.siegmar</groupId>
             <artifactId>logback-gelf</artifactId>
         </dependency>


### PR DESCRIPTION
`release/0.1` had Consul tests from #277 but no Mockito on the test
classpath, which broke the engine release build.