### PR TITLE
fix(runtime-catalog): bump catalog-library to 0.1.15 for service-call template

### DIFF
--- a/runtime-catalog/pom.xml
+++ b/runtime-catalog/pom.xml
@@ -18,7 +18,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <revision>0.1.15</revision>
-        <catalog-library.revision>0.1.14</catalog-library.revision>
+        <catalog-library.revision>0.1.15</catalog-library.revision>
 
         <!-- BOMs -->
 


### PR DESCRIPTION
Set catalog-library.revision to 0.1.15, which includes the PR #194 template change.