### PR TITLE
fix: up Maas versions to actual ones;

### DIFF
--- a/micro-engine/pom.xml
+++ b/micro-engine/pom.xml
@@ -54,8 +54,8 @@
 
         <quarkus-mcp-server.version>1.8.0</quarkus-mcp-server.version>
         <cloud-core.version>10.0.1</cloud-core.version>
-        <maas-client.version>12.0.7</maas-client.version>
-        <maas-client-quarkus.version>10.0.7</maas-client-quarkus.version>
+        <maas-client.version>12.2.1</maas-client.version>
+        <maas-client-quarkus.version>11.0.1</maas-client-quarkus.version>
         <blue-green-state-monitor.version>4.0.1</blue-green-state-monitor.version>
 
         <lombok.version>1.18.46</lombok.version>

--- a/micro-engine/src/main/java/org/qubership/integration/platform/engine/configuration/MaaSClientConfiguration.java
+++ b/micro-engine/src/main/java/org/qubership/integration/platform/engine/configuration/MaaSClientConfiguration.java
@@ -12,6 +12,6 @@ public class MaaSClientConfiguration {
     @Produces
     @ApplicationScoped
     public MaaSAPIClient getMaaSAPIClient() {
-        return new MaaSAPIClientImpl(() -> M2MManager.getInstance().getToken().getTokenValue());
+        return new MaaSAPIClientImpl(() -> M2MManager.getInstance().getToken().getTokenValue(), true);
     }
 }

--- a/micro-engine/src/main/java/org/qubership/integration/platform/engine/kafka/KafkaQueueElementSerializer.java
+++ b/micro-engine/src/main/java/org/qubership/integration/platform/engine/kafka/KafkaQueueElementSerializer.java
@@ -1,0 +1,7 @@
+package org.qubership.integration.platform.engine.kafka;
+
+import io.quarkus.kafka.client.serialization.ObjectMapperSerializer;
+import org.qubership.integration.platform.engine.model.opensearch.KafkaQueueElement;
+
+public class KafkaQueueElementSerializer extends ObjectMapperSerializer<KafkaQueueElement> {
+}

--- a/micro-engine/src/main/java/org/qubership/integration/platform/engine/kafka/MaasOpensearchKafkaProducer.java
+++ b/micro-engine/src/main/java/org/qubership/integration/platform/engine/kafka/MaasOpensearchKafkaProducer.java
@@ -9,6 +9,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.qubership.integration.platform.engine.configuration.tenant.TenantConfiguration;
 import org.qubership.integration.platform.engine.model.opensearch.KafkaQueueElement;
@@ -47,7 +48,9 @@ public class MaasOpensearchKafkaProducer implements OpenSearchKafkaProducer {
                 .orElseThrow(() -> new RuntimeException("Failed to get Kafka topic"));
         producer = new KafkaProducer<>(
                 topicAddress.formatConnectionProperties()
-                        .orElseThrow(() -> new RuntimeException("Failed to get connection Kafka properties"))
+                        .orElseThrow(() -> new RuntimeException("Failed to get connection Kafka properties")),
+                new StringSerializer(),
+                new KafkaQueueElementSerializer()
         );
     }
 

--- a/micro-engine/src/main/resources/application.yml
+++ b/micro-engine/src/main/resources/application.yml
@@ -128,7 +128,7 @@ qip:
       maas:
         enabled: ${OPENSEARCH_KAFKA_MAAS_ENABLED:false}
         classifier:
-          name: ${OPENSEARCH_KAFKA_MAAS_CLASSIFIER_NAME:opersearch.sessions.queue}
+          name: ${OPENSEARCH_KAFKA_MAAS_CLASSIFIER_NAME:opensearch.sessions.queue}
           namespace: ${cloud.microservice.namespace}
           is-tenant: ${OPENSEARCH_KAFKA_MAAS_CLASSIFIER_IS_TENANT:false}
     write:


### PR DESCRIPTION
closes https://github.com/Netcracker/qubership-integration-platform/issues/441
up Maas version
add serializers to constructor of opensearch KafkaProducer in order to fix runtime issue