### PR TITLE
chore(apm): add codex review skill

### DIFF
--- a/.agents/skills/apm-authoring/SKILL.md
+++ b/.agents/skills/apm-authoring/SKILL.md
@@ -32,7 +32,7 @@ agent-packages/
         ├── skills/                  # SKILL.md — on-demand how-tos
         │   └── <package-name>/
         │       └── SKILL.md
-        ├── prompts/                 # optional — *.prompt.md, user-invoked
+        ├── prompts/                 # avoid — Codex skips prompts; use a user-invoked skill
         │   └── <name>.prompt.md
         ├── agents/                  # optional — *.agent.md, sub-agent personas
         │   └── <name>.agent.md
@@ -52,12 +52,15 @@ Rules:
   catalogue is large enough to deserve its own activation). Bundle by
   topic, not by file count — a one-skill package and a five-skill package
   are both fine if each set is internally coherent.
-- Every skill needs a paired instructions file that triggers it.
+- An **auto-triggered** skill needs a paired instructions file.
   Without the trigger merged into `AGENTS.md` / `CLAUDE.md` the agent
   has no signal to pull the skill in. Keep names aligned so the link
-  is obvious from the tree. The reverse is **not** required: a small
+  is obvious from the tree. Two cases need no instruction: a small
   always-true rule may ship as a standalone instruction with no skill
-  behind it (see next section).
+  behind it (see next section), and a **user-invoked** skill — the
+  replacement for a slash-command — carries its activation rule in its
+  own `description:`, so the user invokes it by name and no paired
+  instruction is needed (see "Agents, hooks, and prompts").
 
 The host repo itself is also an APM project: its own AGENTS.md / CLAUDE.md
 must be **rendered by `apm compile`** from a local `.apm/` package plus
@@ -77,8 +80,13 @@ the rule needs to fire and *who* invokes it:
   the agent decides a skill is relevant (steered by the trigger
   phrase in a paired instruction). Cost paid only when activated.
 - **Prompts** (`*.prompt.md`) — slash-commands the **user** invokes
-  explicitly (`/review-pr`). Not loaded into context until called.
-  Use them for repeatable workflows the agent should not auto-trigger.
+  explicitly (`/review-pr`). The primitive exists, but `apm compile`
+  does not deploy it to the Codex target, so a prompt silently
+  vanishes there
+  ([microsoft/apm#1781](https://github.com/microsoft/apm/issues/1781)).
+  For a user-invoked workflow, ship a **skill without a paired
+  instruction** instead (see below): it deploys to every target, and
+  the user still invokes it by name.
 - **Agents** (`*.agent.md` under `agents/`) — sub-agent personalities
   with their own context window and tool-permission boundaries.
   Spawned via `Agent` / `Task`-style tools. Use when a task deserves
@@ -91,10 +99,11 @@ the rule needs to fire and *who* invokes it:
   scanners, log filters) where prose advice is unreliable.
 
 For most library-usage packages the bulk of the work is **one
-instruction** (the trigger) plus **one skill** (the how-to). Prompts,
-agents, and hooks are reserved for the cases the instruction-skill
-pair cannot cover: user-driven workflows, isolated sub-tasks, and
-hard enforcement, respectively.
+instruction** (the trigger) plus **one skill** (the how-to). A
+user-invoked workflow is also a skill — one without a paired
+instruction, invoked by name (see "Agents, hooks, and prompts").
+Agents and hooks are reserved for the two cases the instruction-skill
+pair cannot cover: isolated sub-tasks and hard enforcement.
 
 ### Instruction vs skill: the common case
 
@@ -272,8 +281,9 @@ fetch the [upstream `apm` documentation](https://github.com/microsoft/apm)
 when you reach for one.
 
 The rule that does belong here is about *when* to reach for them:
-**the user decides whether to introduce an agent, a hook, or a
-prompt — do not pick them unilaterally over a skill or instruction.**
+**the user decides whether to introduce an agent or a hook — do not
+pick one unilaterally over a skill or instruction. Don't ship a prompt
+at all; use a user-invoked skill (the Prompts bullet explains why).**
 
 - **Agents** (`*.agent.md`) change the runtime shape — separate
   context budget, restricted tool set, parallelisable. Worth it
@@ -285,9 +295,16 @@ prompt — do not pick them unilaterally over a skill or instruction.**
   secret scanners, log filters) when prose advice has demonstrably
   failed. Don't pre-emptively wire a hook for "good hygiene".
 - **Prompts** (`*.prompt.md`) run only when the user types the
-  slash-command, so they are the safest of the three to suggest.
-  Even so, prefer a skill the agent activates from a trigger over a
-  slash-command the user has to remember to invoke.
+  slash-command. Don't ship one: `apm compile` does not deploy prompts
+  to the Codex target, so a package that relies on a prompt breaks
+  silently for Codex users
+  ([microsoft/apm#1781](https://github.com/microsoft/apm/issues/1781),
+  closed as not planned). For a single-use workflow the user would
+  otherwise invoke as a slash-command, write a **skill without a paired
+  instruction** instead: it deploys to every target, and the user (or
+  another agent) invokes it by name. Put the activation rule in the
+  skill's `description:` — e.g. "Use only when the user asks to triage
+  dependency PRs" — so it does not auto-fire on unrelated turns.
 
 ## Frontmatter and formatting
 
@@ -401,3 +418,6 @@ dependency:
   package's actual name; multiple packages collide otherwise.
 - **Hand-edited AGENTS.md / CLAUDE.md in a repo that already uses
   APM.** Edit the local `.apm/` package and re-run `apm compile`.
+- **Shipping a workflow as a prompt.** `apm compile` skips prompts for
+  the Codex target, so the slash-command silently disappears there.
+  Write a user-invoked skill (no paired instruction) instead.

--- a/.agents/skills/codex-review/SKILL.md
+++ b/.agents/skills/codex-review/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: codex-review
+description: Run a code review through the Codex CLI and apply the fixes — Codex reports findings, you classify each one (real issue vs false positive), fix the real ones, and re-review until the review is clean. Use only when the user asks for a Codex review (cross-review or second opinion) of a branch diff, the uncommitted changes, or a specific commit.
+---
+
+# Codex code review
+
+Use the Codex CLI as a second reviewer: it reads a diff and reports findings, you decide which
+ones are real, fix those, and re-review until Codex comes back clean. The work that needs care is
+the judgement — classifying each finding and writing the fix — so the steps below are mostly about
+driving Codex and keeping a clear record of what was fixed and what was skipped.
+
+Reply in the language the user writes in. Keep code identifiers, paths, and tool names as they are.
+
+## Prerequisites
+
+The [Codex CLI](https://github.com/openai/codex) is installed and authenticated, with `codex` on
+the `PATH`. If `codex` is missing, stop and report it — the rest of the skill depends on it.
+
+## Step 1. Pick the review target
+
+Find out what to review. The target maps to one Codex scope flag:
+
+- `--base <branch>` — the diff against a branch (the common case).
+- `--uncommitted` — the working-tree changes that are not yet committed.
+- `--commit <SHA>` — one specific commit.
+
+If the user already named a target, use it. Otherwise ask with `AskUserQuestion`. Hold the chosen
+flag for the Codex calls below:
+
+```bash
+REVIEW_SCOPE="--base main"   # or "--uncommitted", or "--commit <SHA>"
+```
+
+## Step 2. Pick the review mode
+
+Ask the user which mode to run (`AskUserQuestion`):
+
+- **Automatic** — you classify every finding, then show a summary of what you will fix and what you
+  will skip (with reasons) before touching any code.
+- **Interactive** — for each finding, ask the user to fix it as suggested, skip it, or fix it a
+  different way.
+
+## Step 3. Set up a scratch directory
+
+Keep the intermediate files out of the repository so the review never shows up in the diff it is
+reviewing:
+
+```bash
+CODEX_REVIEW_DIR="$(mktemp -d "${TMPDIR:-${TEMP:-/tmp}}/codex-review-XXXXXX")"
+echo "$CODEX_REVIEW_DIR"
+```
+
+Every later step reads and writes under `$CODEX_REVIEW_DIR`.
+
+## Step 4. Run the first review
+
+```bash
+codex exec review $REVIEW_SCOPE --json -o "$CODEX_REVIEW_DIR/review-output.md" 2>/dev/null
+```
+
+`--json` streams JSONL to stdout, one JSON object per line. Find the line with
+`"type": "session_meta"` and read its `session_id` — step 7 needs it to resume the same Codex
+session. Record the run state in `$CODEX_REVIEW_DIR/state.json`:
+
+```json
+{
+  "session_id": "<session_id from session_meta>",
+  "iteration": 1,
+  "findings": [],
+  "fixed": [],
+  "skipped": []
+}
+```
+
+## Step 5. Classify the findings
+
+Read `$CODEX_REVIEW_DIR/review-output.md` and sort each finding into one of two buckets:
+
+- **Real** — a bug, a missing error path, a security concern, or a style issue worth fixing.
+- **False positive** — irrelevant, debatable, or already handled by surrounding code.
+
+In **automatic** mode, show one summary: the findings you will fix (short descriptions) and the
+ones you will skip (with a reason for each), then proceed without asking per finding.
+
+In **interactive** mode, ask the user per finding: fix as suggested, skip, or fix differently.
+
+Record the findings and decisions in `state.json`.
+
+## Step 6. Apply the fixes
+
+Read the surrounding code first, then edit it — prefer `Edit` over `Write`. When the fixes are in,
+move each finding to the `fixed` or `skipped` array in `state.json`.
+
+## Step 7. Re-review (iterations 2–3)
+
+Resume the same Codex session so it judges the fixes in context rather than starting fresh:
+
+```bash
+codex exec resume "$SESSION_ID" --json -o "$CODEX_REVIEW_DIR/review-output.md" \
+  "I addressed these findings: <fixed items>. I deliberately skipped these, with reasons: \
+<skipped items>. Please re-review."
+```
+
+`$SESSION_ID` is the `session_id` from `state.json`. Increment `iteration`, then repeat steps 5–6
+for any new findings.
+
+Stop the loop when any of these holds:
+
+- Codex reports no new findings.
+- `iteration` reaches 3.
+- The user chooses to stop (in interactive mode, offer this after each iteration).
+
+## Step 8. Final report
+
+Summarise the review. For each finding, show what Codex reported and what you did about it:
+
+```text
+## Review report
+
+Iterations: N
+
+### Finding 1 — [severity] (fixed | skipped)
+- File: path/to/file:Lines
+- Issue: what Codex found, and why it matters.
+- Resolution: the concrete change, or why it was skipped. For a fix, name the before and after
+  (for example, was `MergeLabels(...)`, now `resourceLabelsFromBase(...)`, which also folds in
+  the component labels).
+
+### Verdict: clean | items remaining
+```
+
+Always pair the original finding with its resolution. For a skipped finding, say why (false
+positive, design decision, out of scope).
+
+## Step 9. Clean up
+
+```bash
+rm -rf "$CODEX_REVIEW_DIR"
+```

--- a/.claude/skills/apm-authoring/SKILL.md
+++ b/.claude/skills/apm-authoring/SKILL.md
@@ -32,7 +32,7 @@ agent-packages/
         ├── skills/                  # SKILL.md — on-demand how-tos
         │   └── <package-name>/
         │       └── SKILL.md
-        ├── prompts/                 # optional — *.prompt.md, user-invoked
+        ├── prompts/                 # avoid — Codex skips prompts; use a user-invoked skill
         │   └── <name>.prompt.md
         ├── agents/                  # optional — *.agent.md, sub-agent personas
         │   └── <name>.agent.md
@@ -52,12 +52,15 @@ Rules:
   catalogue is large enough to deserve its own activation). Bundle by
   topic, not by file count — a one-skill package and a five-skill package
   are both fine if each set is internally coherent.
-- Every skill needs a paired instructions file that triggers it.
+- An **auto-triggered** skill needs a paired instructions file.
   Without the trigger merged into `AGENTS.md` / `CLAUDE.md` the agent
   has no signal to pull the skill in. Keep names aligned so the link
-  is obvious from the tree. The reverse is **not** required: a small
+  is obvious from the tree. Two cases need no instruction: a small
   always-true rule may ship as a standalone instruction with no skill
-  behind it (see next section).
+  behind it (see next section), and a **user-invoked** skill — the
+  replacement for a slash-command — carries its activation rule in its
+  own `description:`, so the user invokes it by name and no paired
+  instruction is needed (see "Agents, hooks, and prompts").
 
 The host repo itself is also an APM project: its own AGENTS.md / CLAUDE.md
 must be **rendered by `apm compile`** from a local `.apm/` package plus
@@ -77,8 +80,13 @@ the rule needs to fire and *who* invokes it:
   the agent decides a skill is relevant (steered by the trigger
   phrase in a paired instruction). Cost paid only when activated.
 - **Prompts** (`*.prompt.md`) — slash-commands the **user** invokes
-  explicitly (`/review-pr`). Not loaded into context until called.
-  Use them for repeatable workflows the agent should not auto-trigger.
+  explicitly (`/review-pr`). The primitive exists, but `apm compile`
+  does not deploy it to the Codex target, so a prompt silently
+  vanishes there
+  ([microsoft/apm#1781](https://github.com/microsoft/apm/issues/1781)).
+  For a user-invoked workflow, ship a **skill without a paired
+  instruction** instead (see below): it deploys to every target, and
+  the user still invokes it by name.
 - **Agents** (`*.agent.md` under `agents/`) — sub-agent personalities
   with their own context window and tool-permission boundaries.
   Spawned via `Agent` / `Task`-style tools. Use when a task deserves
@@ -91,10 +99,11 @@ the rule needs to fire and *who* invokes it:
   scanners, log filters) where prose advice is unreliable.
 
 For most library-usage packages the bulk of the work is **one
-instruction** (the trigger) plus **one skill** (the how-to). Prompts,
-agents, and hooks are reserved for the cases the instruction-skill
-pair cannot cover: user-driven workflows, isolated sub-tasks, and
-hard enforcement, respectively.
+instruction** (the trigger) plus **one skill** (the how-to). A
+user-invoked workflow is also a skill — one without a paired
+instruction, invoked by name (see "Agents, hooks, and prompts").
+Agents and hooks are reserved for the two cases the instruction-skill
+pair cannot cover: isolated sub-tasks and hard enforcement.
 
 ### Instruction vs skill: the common case
 
@@ -272,8 +281,9 @@ fetch the [upstream `apm` documentation](https://github.com/microsoft/apm)
 when you reach for one.
 
 The rule that does belong here is about *when* to reach for them:
-**the user decides whether to introduce an agent, a hook, or a
-prompt — do not pick them unilaterally over a skill or instruction.**
+**the user decides whether to introduce an agent or a hook — do not
+pick one unilaterally over a skill or instruction. Don't ship a prompt
+at all; use a user-invoked skill (the Prompts bullet explains why).**
 
 - **Agents** (`*.agent.md`) change the runtime shape — separate
   context budget, restricted tool set, parallelisable. Worth it
@@ -285,9 +295,16 @@ prompt — do not pick them unilaterally over a skill or instruction.**
   secret scanners, log filters) when prose advice has demonstrably
   failed. Don't pre-emptively wire a hook for "good hygiene".
 - **Prompts** (`*.prompt.md`) run only when the user types the
-  slash-command, so they are the safest of the three to suggest.
-  Even so, prefer a skill the agent activates from a trigger over a
-  slash-command the user has to remember to invoke.
+  slash-command. Don't ship one: `apm compile` does not deploy prompts
+  to the Codex target, so a package that relies on a prompt breaks
+  silently for Codex users
+  ([microsoft/apm#1781](https://github.com/microsoft/apm/issues/1781),
+  closed as not planned). For a single-use workflow the user would
+  otherwise invoke as a slash-command, write a **skill without a paired
+  instruction** instead: it deploys to every target, and the user (or
+  another agent) invokes it by name. Put the activation rule in the
+  skill's `description:` — e.g. "Use only when the user asks to triage
+  dependency PRs" — so it does not auto-fire on unrelated turns.
 
 ## Frontmatter and formatting
 
@@ -401,3 +418,6 @@ dependency:
   package's actual name; multiple packages collide otherwise.
 - **Hand-edited AGENTS.md / CLAUDE.md in a repo that already uses
   APM.** Edit the local `.apm/` package and re-run `apm compile`.
+- **Shipping a workflow as a prompt.** `apm compile` skips prompts for
+  the Codex target, so the slash-command silently disappears there.
+  Write a user-invoked skill (no paired instruction) instead.

--- a/.claude/skills/codex-review/SKILL.md
+++ b/.claude/skills/codex-review/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: codex-review
+description: Run a code review through the Codex CLI and apply the fixes — Codex reports findings, you classify each one (real issue vs false positive), fix the real ones, and re-review until the review is clean. Use only when the user asks for a Codex review (cross-review or second opinion) of a branch diff, the uncommitted changes, or a specific commit.
+---
+
+# Codex code review
+
+Use the Codex CLI as a second reviewer: it reads a diff and reports findings, you decide which
+ones are real, fix those, and re-review until Codex comes back clean. The work that needs care is
+the judgement — classifying each finding and writing the fix — so the steps below are mostly about
+driving Codex and keeping a clear record of what was fixed and what was skipped.
+
+Reply in the language the user writes in. Keep code identifiers, paths, and tool names as they are.
+
+## Prerequisites
+
+The [Codex CLI](https://github.com/openai/codex) is installed and authenticated, with `codex` on
+the `PATH`. If `codex` is missing, stop and report it — the rest of the skill depends on it.
+
+## Step 1. Pick the review target
+
+Find out what to review. The target maps to one Codex scope flag:
+
+- `--base <branch>` — the diff against a branch (the common case).
+- `--uncommitted` — the working-tree changes that are not yet committed.
+- `--commit <SHA>` — one specific commit.
+
+If the user already named a target, use it. Otherwise ask with `AskUserQuestion`. Hold the chosen
+flag for the Codex calls below:
+
+```bash
+REVIEW_SCOPE="--base main"   # or "--uncommitted", or "--commit <SHA>"
+```
+
+## Step 2. Pick the review mode
+
+Ask the user which mode to run (`AskUserQuestion`):
+
+- **Automatic** — you classify every finding, then show a summary of what you will fix and what you
+  will skip (with reasons) before touching any code.
+- **Interactive** — for each finding, ask the user to fix it as suggested, skip it, or fix it a
+  different way.
+
+## Step 3. Set up a scratch directory
+
+Keep the intermediate files out of the repository so the review never shows up in the diff it is
+reviewing:
+
+```bash
+CODEX_REVIEW_DIR="$(mktemp -d "${TMPDIR:-${TEMP:-/tmp}}/codex-review-XXXXXX")"
+echo "$CODEX_REVIEW_DIR"
+```
+
+Every later step reads and writes under `$CODEX_REVIEW_DIR`.
+
+## Step 4. Run the first review
+
+```bash
+codex exec review $REVIEW_SCOPE --json -o "$CODEX_REVIEW_DIR/review-output.md" 2>/dev/null
+```
+
+`--json` streams JSONL to stdout, one JSON object per line. Find the line with
+`"type": "session_meta"` and read its `session_id` — step 7 needs it to resume the same Codex
+session. Record the run state in `$CODEX_REVIEW_DIR/state.json`:
+
+```json
+{
+  "session_id": "<session_id from session_meta>",
+  "iteration": 1,
+  "findings": [],
+  "fixed": [],
+  "skipped": []
+}
+```
+
+## Step 5. Classify the findings
+
+Read `$CODEX_REVIEW_DIR/review-output.md` and sort each finding into one of two buckets:
+
+- **Real** — a bug, a missing error path, a security concern, or a style issue worth fixing.
+- **False positive** — irrelevant, debatable, or already handled by surrounding code.
+
+In **automatic** mode, show one summary: the findings you will fix (short descriptions) and the
+ones you will skip (with a reason for each), then proceed without asking per finding.
+
+In **interactive** mode, ask the user per finding: fix as suggested, skip, or fix differently.
+
+Record the findings and decisions in `state.json`.
+
+## Step 6. Apply the fixes
+
+Read the surrounding code first, then edit it — prefer `Edit` over `Write`. When the fixes are in,
+move each finding to the `fixed` or `skipped` array in `state.json`.
+
+## Step 7. Re-review (iterations 2–3)
+
+Resume the same Codex session so it judges the fixes in context rather than starting fresh:
+
+```bash
+codex exec resume "$SESSION_ID" --json -o "$CODEX_REVIEW_DIR/review-output.md" \
+  "I addressed these findings: <fixed items>. I deliberately skipped these, with reasons: \
+<skipped items>. Please re-review."
+```
+
+`$SESSION_ID` is the `session_id` from `state.json`. Increment `iteration`, then repeat steps 5–6
+for any new findings.
+
+Stop the loop when any of these holds:
+
+- Codex reports no new findings.
+- `iteration` reaches 3.
+- The user chooses to stop (in interactive mode, offer this after each iteration).
+
+## Step 8. Final report
+
+Summarise the review. For each finding, show what Codex reported and what you did about it:
+
+```text
+## Review report
+
+Iterations: N
+
+### Finding 1 — [severity] (fixed | skipped)
+- File: path/to/file:Lines
+- Issue: what Codex found, and why it matters.
+- Resolution: the concrete change, or why it was skipped. For a fix, name the before and after
+  (for example, was `MergeLabels(...)`, now `resourceLabelsFromBase(...)`, which also folds in
+  the component labels).
+
+### Verdict: clean | items remaining
+```
+
+Always pair the original finding with its resolution. For a skipped finding, say why (false
+positive, design decision, out of scope).
+
+## Step 9. Clean up
+
+```bash
+rm -rf "$CODEX_REVIEW_DIR"
+```

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,10 +1,12 @@
 lockfile_version: '1'
-generated_at: '2026-06-10T19:31:51.866828+00:00'
-apm_version: 0.19.0
+generated_at: '2026-07-12T18:47:36.297249+00:00'
+apm_version: 0.24.1
 dependencies:
-- repo_url: Netcracker/qubership-ai-packages
+- repo_url: netcracker/qubership-ai-packages
+  name: apm-authoring
   host: github.com
-  resolved_commit: 5317a7b1325eadf5bd1859c6ff92b68b857d40c8
+  resolved_commit: b595ed7de472afff6ef83d517b9fab7143153a87
+  version: 1.0.0
   virtual_path: agent-packages/apm-authoring
   is_virtual: true
   package_type: apm_package
@@ -16,25 +18,48 @@ dependencies:
   - .claude/skills/apm-authoring/SKILL.md
   - .cursor/rules/apm-authoring.mdc
   deployed_file_hashes:
-    .agents/skills/apm-authoring/SKILL.md: sha256:b7f059feadabde6c1016cb5151770d2fc14363730cbb353f546d187489ed596a
+    .agents/skills/apm-authoring/SKILL.md: sha256:1832abc93a14884504dc87d97cc0c2825c7e7b4a6786f2daccf1d6ef172bc907
     .claude/rules/apm-authoring.md: sha256:5c4185d3d69333a810c01f5e26a8ea46b033e7082a21f1551433d6c97d8a24a2
-    .claude/skills/apm-authoring/SKILL.md: sha256:b7f059feadabde6c1016cb5151770d2fc14363730cbb353f546d187489ed596a
+    .claude/skills/apm-authoring/SKILL.md: sha256:1832abc93a14884504dc87d97cc0c2825c7e7b4a6786f2daccf1d6ef172bc907
     .cursor/rules/apm-authoring.mdc: sha256:fbc8f94d4f0b94c04a0ed042ee06f1f48244fdac316f0ce15e2d38b0affbb9aa
-  content_hash: sha256:67d86cc0cae0313cfbfa3e6a16d52c0184bc477711a4d2d668236fca5f7c2c47
+  content_hash: sha256:1d731d0a26376eda0b82629e6e1cff1b41dfeae13fe8d7e5debb24a1699ea4a8
   is_dev: true
-- repo_url: Netcracker/qubership-ai-packages
+- repo_url: netcracker/qubership-ai-packages
+  name: codex-review
   host: github.com
-  resolved_commit: 5317a7b1325eadf5bd1859c6ff92b68b857d40c8
+  resolved_commit: b595ed7de472afff6ef83d517b9fab7143153a87
+  version: 1.0.0
+  virtual_path: agent-packages/codex-review
+  is_virtual: true
+  package_type: apm_package
+  deployed_files:
+  - .agents/skills/codex-review
+  - .agents/skills/codex-review/SKILL.md
+  - .claude/skills/codex-review
+  - .claude/skills/codex-review/SKILL.md
+  deployed_file_hashes:
+    .agents/skills/codex-review/SKILL.md: sha256:2119ddab29ecb75cc470068fc7464419e386f57127e1cdf3bb5e9bbb48609960
+    .claude/skills/codex-review/SKILL.md: sha256:2119ddab29ecb75cc470068fc7464419e386f57127e1cdf3bb5e9bbb48609960
+  content_hash: sha256:2e2ea3193e6bb5e8647f60a6d7777b98a2722ef9146f023d6fda0764bd79d7e5
+- repo_url: netcracker/qubership-ai-packages
+  name: english-developer-style
+  host: github.com
+  resolved_commit: b595ed7de472afff6ef83d517b9fab7143153a87
+  version: 2.0.0
   virtual_path: agent-packages/english-developer-style
   is_virtual: true
   package_type: apm_package
-  content_hash: sha256:d06ce3b1506f828c5698dcab55bfbf0dbb8c9f216185e8f5715c872a88afd6e8
-- repo_url: Netcracker/qubership-ai-packages
+  content_hash: sha256:cdf396ac003a9a1f65a940e150f3e90cd973940ae3fd3f90dcaa227edc26b781
+- repo_url: netcracker/qubership-ai-packages
+  name: english-us-developer-style
   host: github.com
   resolved_commit: 0453aca8531265db34d1299519dd5c8dbde1f307
   resolved_ref: 0453aca8531265db34d1299519dd5c8dbde1f307
+  version: 1.0.2
   virtual_path: agent-packages/english-us-developer-style
   is_virtual: true
+  depth: 2
+  resolved_by: netcracker/qubership-ai-packages
   package_type: apm_package
   deployed_files:
   - .agents/skills/english-us-developer-style

--- a/apm.yml
+++ b/apm.yml
@@ -8,6 +8,7 @@ targets:
 dependencies:
   apm:
     - Netcracker/qubership-ai-packages/agent-packages/english-developer-style
+    - Netcracker/qubership-ai-packages/agent-packages/codex-review
 devDependencies:
   apm:
     - Netcracker/qubership-ai-packages/agent-packages/apm-authoring


### PR DESCRIPTION
## Why

Repository agents need the `codex-review` workflow for Codex CLI cross-reviews and second opinions.

## What

- Add the `codex-review` APM dependency.
- Refresh the APM lockfile and deployed skills.
- Update `apm-authoring` to the resolved upstream revision.

## How to verify

```bash
apm install --frozen
apm audit --ci
```

All nine local APM audit checks pass. The organizational policy fetch depends on network access.