### PR TITLE
fix: #359 restore legacy logic for import instruction entities href generation

### DIFF
--- a/ui/src/components/admin_tools/ImportInstructions.tsx
+++ b/ui/src/components/admin_tools/ImportInstructions.tsx
@@ -141,6 +141,7 @@ const ENTITY_ICON: Record<InstructionEntityType, string> = {
 };
 
 function getEntityHref(row: InstructionRow): string | undefined {
+  if (!row.name) return undefined;
   if (row.entityType === "Chain") return `/chains/${row.id}`;
   if (row.entityType === "Service") return `/services/systems/${row.id}`;
   return undefined;
@@ -189,7 +190,7 @@ function toInstructionRow(
   return {
     key: `${entityType}-${action}-${i.id}`,
     id: i.id,
-    name: i.name ?? i.id,
+    name: i.name,
     entityType,
     action,
     overriddenById: i.overriddenById,
@@ -1007,7 +1008,7 @@ export const UploadInstructionsModal: React.FC<
               {row.name ?? row.id}
             </strong>
           ) : (
-            row.name ?? row.id
+            (row.name ?? row.id)
           ),
       },
       {

--- a/ui/tests/components/admin_tools/ImportInstructions.test.tsx
+++ b/ui/tests/components/admin_tools/ImportInstructions.test.tsx
@@ -246,6 +246,32 @@ describe("ImportInstructions", () => {
     expect(screen.getByText("Var One")).toBeInTheDocument();
   });
 
+  it("should not render entity links when instruction name is missing", async () => {
+    mockApi.getImportInstructions.mockResolvedValueOnce({
+      chains: {
+        ignore: [
+          { id: "existing-chain", name: "Existing Chain" },
+          { id: "missing-chain" },
+        ],
+        override: [],
+        delete: [],
+      },
+      services: { ignore: [{ id: "missing-service" }], delete: [] },
+      specificationGroups: { delete: [], ignore: [] },
+      specifications: { delete: [], ignore: [] },
+      commonVariables: { ignore: [], delete: [] },
+    });
+
+    render(<ImportInstructions />, { wrapper: ContextProviders });
+
+    const existingLink = await screen.findByRole("link", {
+      name: "Existing Chain",
+    });
+    expect(existingLink).toHaveAttribute("href", "/chains/existing-chain");
+    expect((await screen.findByText("missing-chain")).closest("a")).toBeNull();
+    expect(screen.getByText("missing-service").closest("a")).toBeNull();
+  });
+
   it("fetches export on Export button click", async () => {
     render(<ImportInstructions />, { wrapper: ContextProviders });
 
@@ -730,7 +756,7 @@ describe("buildTableData", () => {
     const child = result[0].children![0];
     expect(child.key).toBe("Chain-IGNORE-c2");
     expect(child.action).toBe(ImportInstructionAction.IGNORE);
-    expect(child.name).toBe("c2");
+    expect(child.name).toBeUndefined();
   });
 
   it("maps service-delete into Services group with DELETE action", () => {


### PR DESCRIPTION
links generation logic
- if entity from  backend response contains name filed - generate href
- else ignore and leave id as palin text