### PR TITLE
chore(apm): add AI agent telemetry

### DIFF
--- a/.agents/skills/english-developer-style/SKILL.md
+++ b/.agents/skills/english-developer-style/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: english-us-developer-style
+name: english-developer-style
 description: 'American-English-first style guidance for developer-facing text of any length — README and docs, code comments and docstrings, Javadoc / KDoc / TSDoc / JSDoc, commit messages, PR descriptions and review replies, design docs, changelog entries, UI strings (buttons, labels, placeholders, tooltips), error and log messages, and English-side localization files (.po, .properties, JSON i18n). Use whenever the task involves English developer text — writing, editing, rewriting, translating, localizing, reviewing, proofreading, verifying, auditing, double-checking, or cross-checking. Length does not matter: a one-line `msgstr`, a `// FIXME` comment, or a three-word button label is in scope. Also covers choice of English identifier names (methods, variables, classes, files, tests) read by humans. Covers em-dash usage, hyphen stacking, sentence structure, that/which, gerunds after rather than, hedging, inclusive language, and British/American dialect consistency. Do not use for casual chat replies to the user.'
 ---
 

--- a/.claude/apm-hooks.json
+++ b/.claude/apm-hooks.json
@@ -1,0 +1,16 @@
+{
+  "PreToolUse": [
+    {
+      "matcher": "Skill",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "ai-agent-telemetry ingest --agent=claude",
+          "timeout": 30,
+          "statusMessage": "Recording skill telemetry"
+        }
+      ],
+      "_apm_source": "ai-agent-telemetry"
+    }
+  ]
+}

--- a/.claude/rules/english-developer-style.md
+++ b/.claude/rules/english-developer-style.md
@@ -1,11 +1,11 @@
 ---
-description: American-English-first style rules for developer-facing text of any length — docs, code comments and docstrings inside source files (.go, .js, .ts, .py, .java, .rs, .kt, .cs, ...), commits, PR descriptions, changelogs, UI strings, error and log messages, and English-side localization files (.po, .properties, JSON i18n). Triggered by review/translate/verify/proofread, not only writing.
-globs: "**"
+paths:
+  - "**"
 ---
 
-## Skill trigger: `english-us-developer-style`
+## Skill trigger: `english-developer-style`
 
-**You MUST invoke the `english-us-developer-style` skill BEFORE producing, modifying, translating, or critiquing any
+**You MUST invoke the `english-developer-style` skill BEFORE producing, modifying, translating, or critiquing any
 English developer-facing text.** The skill applies regardless of text length — a one-line error message and a multi-page
 README go through the same checklist.
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ai-agent-telemetry ingest --agent=claude",
+            "timeout": 30,
+            "statusMessage": "Recording skill telemetry"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/english-developer-style/SKILL.md
+++ b/.claude/skills/english-developer-style/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: english-us-developer-style
+name: english-developer-style
 description: 'American-English-first style guidance for developer-facing text of any length — README and docs, code comments and docstrings, Javadoc / KDoc / TSDoc / JSDoc, commit messages, PR descriptions and review replies, design docs, changelog entries, UI strings (buttons, labels, placeholders, tooltips), error and log messages, and English-side localization files (.po, .properties, JSON i18n). Use whenever the task involves English developer text — writing, editing, rewriting, translating, localizing, reviewing, proofreading, verifying, auditing, double-checking, or cross-checking. Length does not matter: a one-line `msgstr`, a `// FIXME` comment, or a three-word button label is in scope. Also covers choice of English identifier names (methods, variables, classes, files, tests) read by humans. Covers em-dash usage, hyphen stacking, sentence structure, that/which, gerunds after rather than, hedging, inclusive language, and British/American dialect consistency. Do not use for casual chat replies to the user.'
 ---
 

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ai-agent-telemetry ingest --agent=codex",
+            "timeout": 30,
+            "statusMessage": "Recording skill telemetry"
+          }
+        ],
+        "_apm_source": "ai-agent-telemetry"
+      }
+    ]
+  }
+}

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,11 @@
+{
+  "hooks": {
+    "afterAgentResponse": [
+      {
+        "command": "ai-agent-telemetry ingest --agent=cursor",
+        "_apm_source": "ai-agent-telemetry"
+      }
+    ]
+  },
+  "version": 1
+}

--- a/.cursor/rules/english-developer-style.mdc
+++ b/.cursor/rules/english-developer-style.mdc
@@ -1,11 +1,11 @@
 ---
-paths:
-  - "**"
+description: American-English-first style rules for developer-facing text of any length — docs, code comments and docstrings inside source files (.go, .js, .ts, .py, .java, .rs, .kt, .cs, ...), commits, PR descriptions, changelogs, UI strings, error and log messages, and English-side localization files (.po, .properties, JSON i18n). Triggered by review/translate/verify/proofread, not only writing.
+globs: "**"
 ---
 
-## Skill trigger: `english-us-developer-style`
+## Skill trigger: `english-developer-style`
 
-**You MUST invoke the `english-us-developer-style` skill BEFORE producing, modifying, translating, or critiquing any
+**You MUST invoke the `english-developer-style` skill BEFORE producing, modifying, translating, or critiquing any
 English developer-facing text.** The skill applies regardless of text length — a one-line error message and a multi-page
 README go through the same checklist.
 

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,11 +1,20 @@
 lockfile_version: '1'
-generated_at: '2026-07-12T18:47:36.297249+00:00'
+generated_at: '2026-07-13T16:31:33.372540+00:00'
 apm_version: 0.24.1
 dependencies:
+- repo_url: netcracker/qubership-ai-agent-telemetry
+  name: ai-agent-telemetry
+  host: github.com
+  resolved_commit: 6ec9a71177fd9dd1a9d0dc134fdccbf255d26a55
+  version: 1.1.0
+  virtual_path: agent-packages/ai-agent-telemetry
+  is_virtual: true
+  package_type: apm_package
+  content_hash: sha256:900bb9fe3c6dee45ea5f0f32bc08d1962a21f0dc1f1dbefd2bf3279b33c93bf0
 - repo_url: netcracker/qubership-ai-packages
   name: apm-authoring
   host: github.com
-  resolved_commit: b595ed7de472afff6ef83d517b9fab7143153a87
+  resolved_commit: b5c51a1eaa16ac523d94008db6dd5ed5d946ea08
   version: 1.0.0
   virtual_path: agent-packages/apm-authoring
   is_virtual: true
@@ -27,7 +36,7 @@ dependencies:
 - repo_url: netcracker/qubership-ai-packages
   name: codex-review
   host: github.com
-  resolved_commit: b595ed7de472afff6ef83d517b9fab7143153a87
+  resolved_commit: b5c51a1eaa16ac523d94008db6dd5ed5d946ea08
   version: 1.0.0
   virtual_path: agent-packages/codex-review
   is_virtual: true
@@ -44,36 +53,36 @@ dependencies:
 - repo_url: netcracker/qubership-ai-packages
   name: english-developer-style
   host: github.com
-  resolved_commit: b595ed7de472afff6ef83d517b9fab7143153a87
-  version: 2.0.0
+  resolved_commit: b5c51a1eaa16ac523d94008db6dd5ed5d946ea08
+  version: 2.0.1
   virtual_path: agent-packages/english-developer-style
   is_virtual: true
   package_type: apm_package
-  content_hash: sha256:cdf396ac003a9a1f65a940e150f3e90cd973940ae3fd3f90dcaa227edc26b781
+  content_hash: sha256:c7a28df93a78f7f9beb609e1ea6cfaa59e818d73b6b017e949c71b45806a065f
 - repo_url: netcracker/qubership-ai-packages
   name: english-us-developer-style
   host: github.com
-  resolved_commit: 0453aca8531265db34d1299519dd5c8dbde1f307
-  resolved_ref: 0453aca8531265db34d1299519dd5c8dbde1f307
-  version: 1.0.2
+  resolved_commit: cb31b6ce4d9457d2638b40590500a5229c230d99
+  resolved_ref: cb31b6ce4d9457d2638b40590500a5229c230d99
+  version: 2.0.0
   virtual_path: agent-packages/english-us-developer-style
   is_virtual: true
   depth: 2
   resolved_by: netcracker/qubership-ai-packages
   package_type: apm_package
   deployed_files:
-  - .agents/skills/english-us-developer-style
-  - .agents/skills/english-us-developer-style/SKILL.md
-  - .claude/rules/english-us-developer-style.md
-  - .claude/skills/english-us-developer-style
-  - .claude/skills/english-us-developer-style/SKILL.md
-  - .cursor/rules/english-us-developer-style.mdc
+  - .agents/skills/english-developer-style
+  - .agents/skills/english-developer-style/SKILL.md
+  - .claude/rules/english-developer-style.md
+  - .claude/skills/english-developer-style
+  - .claude/skills/english-developer-style/SKILL.md
+  - .cursor/rules/english-developer-style.mdc
   deployed_file_hashes:
-    .agents/skills/english-us-developer-style/SKILL.md: sha256:29ad7156586f8265dab3f7e55b257f2a9b3cb1b78b99180d7f7b362f5e11b74c
-    .claude/rules/english-us-developer-style.md: sha256:50cb5c3eb0809ebdfa3fb5a95b6234c95b47905ce82c05e2be2334cee5b16f14
-    .claude/skills/english-us-developer-style/SKILL.md: sha256:29ad7156586f8265dab3f7e55b257f2a9b3cb1b78b99180d7f7b362f5e11b74c
-    .cursor/rules/english-us-developer-style.mdc: sha256:dbc642bc4c4de0abc3a3f0cc2a623713c8967936ab1ad49ba42829c83214b10b
-  content_hash: sha256:81ed9935f43fbcf4aab9a7a3d41f5cd273cb293b7e7d2136bdace53add6ad0a0
+    .agents/skills/english-developer-style/SKILL.md: sha256:c91fecf2c209428808e1c9ffc0cbe6cd735bd0786e266be533620e8164367da7
+    .claude/rules/english-developer-style.md: sha256:7b837ce6ca63996064b7eb7378a54b484f9905a7102d18ee009ee2e1fb9edf7a
+    .claude/skills/english-developer-style/SKILL.md: sha256:c91fecf2c209428808e1c9ffc0cbe6cd735bd0786e266be533620e8164367da7
+    .cursor/rules/english-developer-style.mdc: sha256:77065463f554e95f32be987d5a51849ded6e621515ea1b8e9dd61530c3046928
+  content_hash: sha256:30311d4be0a1b4111895a3ac1f67183ba0a1a64a99f3ed09724ae4731682c8b9
 local_deployed_files:
 - .agents/skills/ui-api-and-utilities
 - .agents/skills/ui-api-and-utilities/SKILL.md

--- a/apm.yml
+++ b/apm.yml
@@ -9,6 +9,7 @@ dependencies:
   apm:
     - Netcracker/qubership-ai-packages/agent-packages/english-developer-style
     - Netcracker/qubership-ai-packages/agent-packages/codex-review
+    - Netcracker/qubership-ai-agent-telemetry/agent-packages/ai-agent-telemetry
 devDependencies:
   apm:
     - Netcracker/qubership-ai-packages/agent-packages/apm-authoring


### PR DESCRIPTION
## Why

Repository agents need telemetry hooks to record skill usage for the configured Claude, Codex, and Cursor targets.

## What

- Add the `ai-agent-telemetry` APM dependency.
- Deploy the generated telemetry hook configurations for Claude, Codex, and Cursor.
- Refresh the APM lockfile and deployed English-style package paths.
- Preserve the upstream Cursor hook as generated. APM warns that `afterAgentResponse` may not be recognized because Cursor expects PascalCase event names. APM also reports that filename-based target routing is deprecated in the upstream package.

## How to verify

```bash
apm install --frozen
apm audit --ci
```

All nine local APM audit checks pass with no drift. The organizational policy fetch requires network access.