### PR TITLE
fix(ui): restore Ant Design 6 overlay and tab layouts

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -87,27 +87,29 @@ h1 {
 
 .flex-tabs {
   min-height: 0;
-  flex-grow: 1;
-  flex-shrink: 1;
+  flex: 1 1 0;
+}
 
-  .ant-tabs-content-holder {
-    display: flex;
-    flex-direction: column;
-  }
+.flex-tabs .ant-tabs-body-holder,
+.flex-tabs .ant-tabs-body {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-height: 0;
+}
 
-  .ant-tabs-content {
-    flex-shrink: 1;
-    flex-grow: 1;
-    display: flex;
-    flex-direction: column;
-    min-height: 0;
-  }
+.flex-tabs .ant-tabs-content {
+  flex: 1 1 auto;
+  min-height: 0;
+}
 
-  .ant-tabs-tabpane {
-    flex-grow: 1;
-    flex-shrink: 1;
-    min-height: 0;
-  }
+.flex-tabs .ant-tabs-content-active {
+  display: flex;
+  flex-direction: column;
+}
+
+.flex-tabs .ant-tabs-content-hidden {
+  display: none;
 }
 
 .flex-table {
@@ -155,6 +157,8 @@ h1 {
 }
 
 .qip-editor {
+  min-width: 0;
+  min-height: 0;
   border: solid 1px var(--vscode-border, lightgrey);
   border-radius: 4px;
   margin-top: 8px;

--- a/ui/src/styles/theme-variables.css
+++ b/ui/src/styles/theme-variables.css
@@ -233,17 +233,9 @@
   );
 }
 
-/* Smooth theme transitions */
+/* Prevent intermediate colors while theme variables are changing. */
 .theme-switching * {
   transition: none !important;
-}
-
-:root:not(.theme-switching) * {
-  transition:
-    background-color var(--transition-duration) ease,
-    color var(--transition-duration) ease,
-    border-color var(--transition-duration) ease,
-    box-shadow var(--transition-duration) ease;
 }
 
 /* Apply theme to body */

--- a/ui/tests/styles/antdV6LayoutContracts.test.ts
+++ b/ui/tests/styles/antdV6LayoutContracts.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const sourceRoot = resolve(__dirname, "../../src");
+
+function readStyle(relativePath: string): string {
+  return readFileSync(resolve(sourceRoot, relativePath), "utf8");
+}
+
+function declarationsFor(css: string, selector: string): string {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = css.match(new RegExp(`${escapedSelector}\\s*\\{([^{}]*)\\}`));
+  return match?.[1].replace(/\\s+/g, " ").trim() ?? "";
+}
+
+describe("Ant Design 6 global style contracts", () => {
+  it("does not replace component transitions outside a theme switch", () => {
+    const css = readStyle("styles/theme-variables.css");
+
+    expect(css).not.toMatch(/:root:not\(\.theme-switching\)\s*\*/);
+    expect(declarationsFor(css, ".theme-switching *")).toContain(
+      "transition: none !important",
+    );
+  });
+});

--- a/ui/tests/styles/antdV6LayoutContracts.test.ts
+++ b/ui/tests/styles/antdV6LayoutContracts.test.ts
@@ -8,9 +8,16 @@ function readStyle(relativePath: string): string {
 }
 
 function declarationsFor(css: string, selector: string): string {
-  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const match = css.match(new RegExp(`${escapedSelector}\\s*\\{([^{}]*)\\}`));
-  return match?.[1].replace(/\\s+/g, " ").trim() ?? "";
+  const rulePattern = /([^{}]+)\{([^{}]*)\}/g;
+  const stylesheet = css.replace(/\/\*[\s\S]*?\*\//g, "");
+
+  for (const match of stylesheet.matchAll(rulePattern)) {
+    if (match[1].split(",").some((item) => item.trim() === selector)) {
+      return match[2].replace(/\s+/g, " ").trim();
+    }
+  }
+
+  return "";
 }
 
 describe("Ant Design 6 global style contracts", () => {
@@ -21,5 +28,35 @@ describe("Ant Design 6 global style contracts", () => {
     expect(declarationsFor(css, ".theme-switching *")).toContain(
       "transition: none !important",
     );
+  });
+
+  it("targets the Ant Design 6 tab body structure", () => {
+    const css = readStyle("index.css");
+
+    expect(declarationsFor(css, ".flex-tabs .ant-tabs-body-holder")).toContain(
+      "display: flex",
+    );
+    expect(declarationsFor(css, ".flex-tabs .ant-tabs-body")).toContain(
+      "flex: 1 1 auto",
+    );
+    expect(
+      declarationsFor(css, ".flex-tabs .ant-tabs-content-active"),
+    ).toContain("display: flex");
+  });
+
+  it("keeps inactive Ant Design tabs out of the layout", () => {
+    const css = readStyle("index.css");
+
+    expect(
+      declarationsFor(css, ".flex-tabs .ant-tabs-content-hidden"),
+    ).toContain("display: none");
+  });
+
+  it("allows Monaco wrappers to shrink inside flex layouts", () => {
+    const css = readStyle("index.css");
+    const declarations = declarationsFor(css, ".qip-editor");
+
+    expect(declarations).toContain("min-height: 0");
+    expect(declarations).toContain("min-width: 0");
   });
 });


### PR DESCRIPTION
## Why

The Ant Design 6 upgrade caused dismissed notifications to intercept clicks, inactive service tab tables to remain in the layout, and Monaco editors in session body views to collapse vertically.

## What

- Restore component-managed transitions by removing the global transition override.
- Update flex tab selectors for the Ant Design 6 body and content structure.
- Keep inactive tab panels out of the layout and propagate available height to active panels.
- Allow Monaco wrappers to shrink correctly in flex layouts.
- Add CSS contract tests for the affected behavior.

## How to verify

- Run: npm test -- tests/styles/antdV6LayoutContracts.test.ts --runInBand --coverage=false
- Run: npm run check-types
- Run: npm run lint
- Run: npm run build
- Trigger and dismiss a notification, then click the area that it occupied.
- Switch among service tabs and confirm that only the active table remains visible.
- Open a session body view and confirm that the Monaco editor fills the available height.

The focused tests, type check, lint, and production build pass. A manual smoke test against the local backend confirmed the three affected UI scenarios. The full Jest suite still has three unrelated failures in ChainElementModification and Diagnostic tests; the same failures reproduce on the base branch.