### PR TITLE
fix: fixed removed state in chain comparison

### DIFF
--- a/ui/src/components/chains/diff/ChainDiffGraphView.tsx
+++ b/ui/src/components/chains/diff/ChainDiffGraphView.tsx
@@ -28,7 +28,9 @@ export function getElementId(
 export type ChainDiffGraphViewProps = {
   chain1?: Chain;
   chain2?: Chain;
-  changes: Change[];
+  // Undefined means there is no valid comparison yet; the graph panes stay
+  // empty instead of rendering misleading node states.
+  changes?: Change[];
   selectedChangeId?: string;
   onSelectChange: (id: string) => void;
 };
@@ -44,7 +46,7 @@ export const ChainDiffGraphView: React.FC<ChainDiffGraphViewProps> = ({
   );
 
   useEffect(() => {
-    setSelectedChange(changes.find((c) => c.id === selectedChangeId));
+    setSelectedChange(changes?.find((c) => c.id === selectedChangeId));
   }, [changes, selectedChangeId]);
 
   const elementMap = useMemo(() => {
@@ -85,7 +87,7 @@ export const ChainDiffGraphView: React.FC<ChainDiffGraphViewProps> = ({
       </Row>
       <Row gutter={16} style={{ minHeight: 0, flexGrow: 1, flexShrink: 0 }}>
         <Col span={12}>
-          {chain1 ? (
+          {chain1 && chain2 && changes ? (
             <DiffDocumentContextProvider type={"left"}>
               <ChainGraphChangeProvider
                 chain={chain1}
@@ -103,7 +105,7 @@ export const ChainDiffGraphView: React.FC<ChainDiffGraphViewProps> = ({
           ) : null}
         </Col>
         <Col span={12}>
-          {chain2 ? (
+          {chain1 && chain2 && changes ? (
             <DiffDocumentContextProvider type={"right"}>
               <ChainGraphChangeProvider
                 chain={chain2}

--- a/ui/src/components/chains/diff/ChainDiffView.tsx
+++ b/ui/src/components/chains/diff/ChainDiffView.tsx
@@ -66,7 +66,7 @@ export const ChainDiffView: React.FC<ChainDiffViewProps> = ({
         </Col>
       </Row>
       <ChainDiffViewControls
-        changes={changes}
+        changes={changes ?? []}
         selectedChangeId={selectedChangeId}
         onSelectChange={setSelectedChangeId}
         onViewTypeChange={(viewType) => setViewType(viewType)}
@@ -84,7 +84,7 @@ export const ChainDiffView: React.FC<ChainDiffViewProps> = ({
           <ChainDiffTableView
             chain1={chain1}
             chain2={chain2}
-            changes={changes}
+            changes={changes ?? []}
             selectedChangeId={selectedChangeId}
             onSelectChange={setSelectedChangeId}
           />
@@ -92,7 +92,7 @@ export const ChainDiffView: React.FC<ChainDiffViewProps> = ({
           <ChainDiffTextView
             chain1={chain1}
             chain2={chain2}
-            changes={changes}
+            changes={changes ?? []}
             selectedChangeId={selectedChangeId}
             onSelectChange={setSelectedChangeId}
           />

--- a/ui/src/components/chains/diff/ChainGraphChangeProvider.tsx
+++ b/ui/src/components/chains/diff/ChainGraphChangeProvider.tsx
@@ -38,20 +38,28 @@ export function createNodeStateMap(
   elementMap: Map<string, string>,
 ): Map<string, NodeState> {
   const m = new Map<string, NodeState>();
+  // Follows the side-by-side diff convention: a change with no counterpart on
+  // the opposite side is a removal on the "one" (left) pane and an addition on
+  // the "another" (right) pane.
+  const oneSidedState = side === "one" ? NodeState.REMOVED : NodeState.CREATED;
+  const oppositeSide = getOppositeSide(side);
   traverseElementsDepthFirst(chain.elements, (element) => {
-    const change = changes.find(
+    const matches = changes.filter(
       (c) =>
         (c.kind === "element" && c[side]?.id === element.id) ||
         (c.kind === "element-property" && c[side]?.entityId === element.id),
     );
-    const oppositeSide = getOppositeSide(side);
-    const state = change
-      ? change[oppositeSide] === undefined
-        ? NodeState.CREATED
-        : NodeState.CHANGED
-      : elementMap.get(element.id)
-        ? NodeState.NOT_CHANGED
-        : NodeState.REMOVED;
+    // A two-sided change is a modification and dominates one-sided property
+    // changes on the same element, so the state does not depend on change
+    // order.
+    const state =
+      matches.length > 0
+        ? matches.some((c) => c[oppositeSide] !== undefined)
+          ? NodeState.CHANGED
+          : oneSidedState
+        : elementMap.get(element.id)
+          ? NodeState.NOT_CHANGED
+          : oneSidedState;
     m.set(element.id, state);
   });
   return m;

--- a/ui/src/components/chains/diff/useChainDiff.tsx
+++ b/ui/src/components/chains/diff/useChainDiff.tsx
@@ -1,5 +1,5 @@
 import { Chain, ChainSnapshot } from "../../../api/apiTypes.ts";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNotificationService } from "../../../hooks/useNotificationService.tsx";
 import { api } from "../../../api/api.ts";
 import { Change } from "./compare/types.ts";
@@ -50,12 +50,9 @@ export function asChain(snapshot: ChainSnapshot): Chain {
 export const useChainDiff = (item1: ComparableItem, item2: ComparableItem) => {
   const [chain1, setChain1] = useState<Chain | undefined>();
   const [chain2, setChain2] = useState<Chain | undefined>();
-  const [changes, setChanges] = useState<Change[]>([]);
 
-  const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isChain1Loading, setIsChain1Loading] = useState<boolean>(false);
   const [isChain2Loading, setIsChain2Loading] = useState<boolean>(false);
-  const [isComparing, setIsComparing] = useState<boolean>(false);
 
   const [selectedChangeId, setSelectedChangeId] = useState<
     string | undefined
@@ -130,22 +127,6 @@ export const useChainDiff = (item1: ComparableItem, item2: ComparableItem) => {
     [loadChain, loadSnapshot, loadChainFromArchive],
   );
 
-  const compareChains = useCallback(
-    async (chain1: Chain, chain2: Chain): Promise<Change[]> => {
-      try {
-        setIsComparing(true);
-        return await (async () =>
-          Promise.resolve(doCompareChains(chain1, chain2)))();
-      } catch (e) {
-        notificationService.errorWithDetails("Failed to compare chains", "", e);
-        return [];
-      } finally {
-        setIsComparing(false);
-      }
-    },
-    [notificationService],
-  );
-
   useEffect(() => {
     void loadItem(item1, setIsChain1Loading).then(setChain1);
   }, [item1, loadItem]);
@@ -154,16 +135,36 @@ export const useChainDiff = (item1: ComparableItem, item2: ComparableItem) => {
     void loadItem(item2, setIsChain2Loading).then(setChain2);
   }, [item2, loadItem]);
 
-  useEffect(() => {
+  // Deriving the comparison synchronously leaves no render frame where both
+  // chains are set but the changes describe older inputs. An undefined result
+  // means there is no valid comparison: a chain is missing or the compare
+  // threw.
+  const comparison = useMemo(():
+    | { changes: Change[]; error?: never }
+    | { changes?: never; error: unknown }
+    | undefined => {
     if (!chain1 || !chain2) {
-      return;
+      return undefined;
     }
-    void compareChains(chain1, chain2).then(setChanges);
-  }, [chain1, chain2, compareChains]);
+    try {
+      return { changes: doCompareChains(chain1, chain2) };
+    } catch (e) {
+      return { error: e };
+    }
+  }, [chain1, chain2]);
 
   useEffect(() => {
-    setIsLoading(isChain1Loading || isChain2Loading || isComparing);
-  }, [isChain1Loading, isChain2Loading, isComparing]);
+    if (comparison?.error) {
+      notificationService.errorWithDetails(
+        "Failed to compare chains",
+        "",
+        comparison.error,
+      );
+    }
+  }, [comparison, notificationService]);
+
+  const changes = comparison?.changes;
+  const isLoading = isChain1Loading || isChain2Loading;
 
   return {
     isLoading,

--- a/ui/tests/components/chains/diff/ChainDiffGraphView.test.tsx
+++ b/ui/tests/components/chains/diff/ChainDiffGraphView.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import type { Chain } from "../../../../src/api/apiTypes";
+import type { ChainDiffGraphViewProps } from "../../../../src/components/chains/diff/ChainDiffGraphView";
+
+jest.mock("antd", () => ({
+  Flex: jest.fn(({ children }: any) => <div>{children}</div>),
+  Row: jest.fn(({ children }: any) => <div>{children}</div>),
+  Col: jest.fn(({ children }: any) => <div>{children}</div>),
+  Tag: jest.fn(({ children }: any) => <span>{children}</span>),
+}));
+
+jest.mock("../../../../src/components/chains/diff/ChainGraphPanel.tsx", () => ({
+  ChainGraphPanel: jest.fn(() => <div data-testid="chain-graph-panel" />),
+}));
+
+jest.mock(
+  "../../../../src/components/chains/diff/ChangedEntityView.tsx",
+  () => ({
+    ChangedEntityView: jest.fn(() => <div data-testid="changed-entity-view" />),
+  }),
+);
+
+jest.mock(
+  "../../../../src/components/chains/diff/DiffDocumentContext.tsx",
+  () => ({
+    DiffDocumentContextProvider: jest.fn(({ children }: any) => (
+      <>{children}</>
+    )),
+  }),
+);
+
+jest.mock(
+  "../../../../src/components/chains/diff/ChainGraphChangeProvider.tsx",
+  () => ({
+    ChainGraphChangeProvider: jest.fn(({ children }: any) => <>{children}</>),
+  }),
+);
+
+import { ChainDiffGraphView } from "../../../../src/components/chains/diff/ChainDiffGraphView";
+
+const chain1 = {
+  id: "chain-1",
+  elements: [],
+  dependencies: [],
+} as unknown as Chain;
+const chain2 = {
+  id: "chain-2",
+  elements: [],
+  dependencies: [],
+} as unknown as Chain;
+
+function renderView(props: {
+  chain1?: Chain;
+  chain2?: Chain;
+  changes?: ChainDiffGraphViewProps["changes"];
+}) {
+  return render(<ChainDiffGraphView {...props} onSelectChange={jest.fn()} />);
+}
+
+describe("ChainDiffGraphView", () => {
+  it("should not render graph panes when changes is undefined", () => {
+    renderView({ chain1, chain2, changes: undefined });
+
+    expect(screen.queryAllByTestId("chain-graph-panel")).toHaveLength(0);
+  });
+
+  it("should not render graph panes when a chain is missing even though changes are present", () => {
+    renderView({ chain1, chain2: undefined, changes: [] });
+
+    expect(screen.queryAllByTestId("chain-graph-panel")).toHaveLength(0);
+  });
+
+  it("should render both graph panes when both chains and changes are present", () => {
+    renderView({ chain1, chain2, changes: [] });
+
+    expect(screen.getAllByTestId("chain-graph-panel")).toHaveLength(2);
+  });
+});

--- a/ui/tests/components/chains/diff/ChainGraphChangeProvider.test.ts
+++ b/ui/tests/components/chains/diff/ChainGraphChangeProvider.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "@jest/globals";
+import type { Chain, Element } from "../../../../src/api/apiTypes";
+import type { Change } from "../../../../src/components/chains/diff/compare/types";
+import {
+  createNodeStateMap,
+  NodeState,
+} from "../../../../src/components/chains/diff/ChainGraphChangeProvider";
+
+function element(id: string): Element {
+  return { id, name: id, type: "sender", properties: {} } as unknown as Element;
+}
+
+function chainOf(...elements: Element[]): Chain {
+  return { id: "chain", elements, dependencies: [] } as unknown as Chain;
+}
+
+function elementChange(side: "one" | "another", e: Element): Change {
+  return { id: `change-${e.id}`, kind: "element", [side]: e };
+}
+
+function propertyChange(
+  entityIds: { one?: string; another?: string },
+  name = "prop",
+): Change {
+  return {
+    id: `change-${name}-${entityIds.one ?? entityIds.another}`,
+    kind: "element-property",
+    one: entityIds.one
+      ? { entityId: entityIds.one, name, value: "v1" }
+      : undefined,
+    another: entityIds.another
+      ? { entityId: entityIds.another, name, value: "v2" }
+      : undefined,
+  };
+}
+
+describe("createNodeStateMap", () => {
+  it("should mark element NOT_CHANGED when no change matches and the element is mapped", () => {
+    const a = element("a");
+    const elementMap = new Map([
+      ["a", "b"],
+      ["b", "a"],
+    ]);
+
+    const states = createNodeStateMap(chainOf(a), "one", [], elementMap);
+
+    expect(states.get("a")).toBe(NodeState.NOT_CHANGED);
+  });
+
+  it("should mark element CHANGED when a two-sided property change matches", () => {
+    const a = element("a");
+    const changes = [propertyChange({ one: "a", another: "b" })];
+    const elementMap = new Map([
+      ["a", "b"],
+      ["b", "a"],
+    ]);
+
+    const states = createNodeStateMap(chainOf(a), "one", changes, elementMap);
+
+    expect(states.get("a")).toBe(NodeState.CHANGED);
+  });
+
+  it("should mark element REMOVED on side one when the element has no counterpart", () => {
+    const a = element("a");
+    const changes = [elementChange("one", a)];
+
+    const states = createNodeStateMap(chainOf(a), "one", changes, new Map());
+
+    expect(states.get("a")).toBe(NodeState.REMOVED);
+  });
+
+  it("should mark element CREATED on side another when the element has no counterpart", () => {
+    const b = element("b");
+    const changes = [elementChange("another", b)];
+
+    const states = createNodeStateMap(
+      chainOf(b),
+      "another",
+      changes,
+      new Map(),
+    );
+
+    expect(states.get("b")).toBe(NodeState.CREATED);
+  });
+
+  it("should mark element REMOVED on side one when its only property change is one-sided", () => {
+    const a = element("a");
+    const changes = [propertyChange({ one: "a" })];
+    const elementMap = new Map([
+      ["a", "b"],
+      ["b", "a"],
+    ]);
+
+    const states = createNodeStateMap(chainOf(a), "one", changes, elementMap);
+
+    expect(states.get("a")).toBe(NodeState.REMOVED);
+  });
+
+  it("should mark element CREATED on side another when its only property change is one-sided", () => {
+    const b = element("b");
+    const changes = [propertyChange({ another: "b" })];
+    const elementMap = new Map([
+      ["a", "b"],
+      ["b", "a"],
+    ]);
+
+    const states = createNodeStateMap(
+      chainOf(b),
+      "another",
+      changes,
+      elementMap,
+    );
+
+    expect(states.get("b")).toBe(NodeState.CREATED);
+  });
+
+  it("should mark element CHANGED when both one-sided and two-sided property changes match", () => {
+    const a = element("a");
+    const changes = [
+      propertyChange({ one: "a" }, "removed-prop"),
+      propertyChange({ one: "a", another: "b" }, "modified-prop"),
+    ];
+    const elementMap = new Map([
+      ["a", "b"],
+      ["b", "a"],
+    ]);
+
+    const states = createNodeStateMap(chainOf(a), "one", changes, elementMap);
+
+    expect(states.get("a")).toBe(NodeState.CHANGED);
+  });
+
+  it("should fall back to the one-sided state when an unmapped element has no matching change", () => {
+    const a = element("a");
+    const b = element("b");
+
+    const oneStates = createNodeStateMap(chainOf(a), "one", [], new Map());
+    const anotherStates = createNodeStateMap(
+      chainOf(b),
+      "another",
+      [],
+      new Map(),
+    );
+
+    expect(oneStates.get("a")).toBe(NodeState.REMOVED);
+    expect(anotherStates.get("b")).toBe(NodeState.CREATED);
+  });
+
+  it("should classify nested children independently of their parents", () => {
+    const child = element("child");
+    const parent = { ...element("parent"), children: [child] };
+    const changes = [elementChange("one", child)];
+    const elementMap = new Map([
+      ["parent", "parent-2"],
+      ["parent-2", "parent"],
+    ]);
+
+    const states = createNodeStateMap(
+      chainOf(parent),
+      "one",
+      changes,
+      elementMap,
+    );
+
+    expect(states.get("parent")).toBe(NodeState.NOT_CHANGED);
+    expect(states.get("child")).toBe(NodeState.REMOVED);
+  });
+});

--- a/ui/tests/components/chains/diff/useChainDiff.test.tsx
+++ b/ui/tests/components/chains/diff/useChainDiff.test.tsx
@@ -49,14 +49,14 @@ describe("useChainDiff", () => {
     mockCompareChains.mockReturnValue([]);
   });
 
-  it("should return undefined chains, empty changes, and undefined selectedChangeId when first rendered", () => {
+  it("should return undefined chains, undefined changes, and undefined selectedChangeId when first rendered", () => {
     mockGetChain.mockImplementation(resolveById);
 
     const { result } = renderHook(() => useChainDiff(item1, item2));
 
     expect(result.current.chain1).toBeUndefined();
     expect(result.current.chain2).toBeUndefined();
-    expect(result.current.changes).toEqual([]);
+    expect(result.current.changes).toBeUndefined();
     expect(result.current.selectedChangeId).toBeUndefined();
   });
 
@@ -147,6 +147,22 @@ describe("useChainDiff", () => {
     expect(mockCompareChains).not.toHaveBeenCalled();
   });
 
+  it("should keep changes undefined when only one chain has loaded", async () => {
+    mockGetChain.mockImplementation((id: string) =>
+      id === "chain-1"
+        ? Promise.resolve(chain1)
+        : Promise.reject(new Error("Not found")),
+    );
+
+    const { result } = renderHook(() => useChainDiff(item1, item2));
+
+    await waitFor(() => {
+      expect(result.current.chain1).toEqual(chain1);
+    });
+
+    expect(result.current.changes).toBeUndefined();
+  });
+
   it("should call notificationService.requestFailed when fetching chain1 throws", async () => {
     const error = new Error("Chain 1 load failed");
     mockGetChain.mockImplementation((id: string) =>
@@ -197,7 +213,7 @@ describe("useChainDiff", () => {
     });
   });
 
-  it("should keep changes as an empty array when compareChains throws", async () => {
+  it("should leave changes undefined when compareChains throws", async () => {
     mockGetChain.mockImplementation(resolveById);
     mockCompareChains.mockImplementation(() => {
       throw new Error("Compare failed");
@@ -209,7 +225,7 @@ describe("useChainDiff", () => {
       expect(mockErrorWithDetails).toHaveBeenCalled();
     });
 
-    expect(result.current.changes).toEqual([]);
+    expect(result.current.changes).toBeUndefined();
   });
 
   it("should reload chain1 and re-run comparison when chainId1 changes", async () => {


### PR DESCRIPTION
closes #411 

* The behavior now follows the side-by-side diff convention: a change with no counterpart on the opposite side is a removal on the "one" (left) pane and an addition on the "another" (right) pane.
* Fixed async gap / load failure: useChainDiff computes changes asynchronously in an effect (useChainDiff.tsx:157-162), while ChainDiffGraphView builds elementMap synchronously in useMemo (ChainDiffGraphView.tsx:50-54). While chain2 is still loading (or failed to load), the left pane renders with changes = [] and an empty elementMap → every chain1 node is REMOVED. There's also a one-render flash after both chains load but before setChanges lands.