### PR TITLE
feat: added custom chain diff toggle

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -16,7 +16,8 @@
   },
   "enabledApiProposals": [
     "tunnels",
-    "customEditorDiffs"
+    "customEditorDiffs",
+    "customEditorPriority"
   ],
   "categories": [
     "Other"
@@ -32,6 +33,21 @@
   ],
   "browser": "./dist/web/extension.js",
   "contributes": {
+    "configurationDefaults": {
+      "workbench.diffEditorAssociations": {
+        "*.chain.qip.yaml": "qip.chainFile.editor"
+      }
+    },
+    "configuration": {
+      "title": "Qubership Integration Platform Extension",
+      "properties": {
+        "qipExtension.useDefaultDiffView": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Open integration chain diffs in the built-in text diff editor instead of the QIP visual diff. Toggling this updates the `workbench.diffEditorAssociations` entry for `*.chain.qip.yaml` in your user settings."
+        }
+      }
+    },
     "commands": [
       {
         "command": "qip.open",
@@ -98,7 +114,11 @@
             "filenamePattern": "*.chain.qip.yaml"
           }
         ],
-        "diffEditorPriority": "option"
+        "priority": {
+          "textEditor": "default",
+          "diffEditor": "default",
+          "mergeEditor": "never"
+        }
       },
       {
         "viewType": "qip.serviceFile.editor",

--- a/vscode-extension/src/web/extension.ts
+++ b/vscode-extension/src/web/extension.ts
@@ -345,6 +345,50 @@ class ChainFileEditorProvider extends BaseFileEditorProvider {
   }
 }
 
+const DIFF_EDITOR_ASSOCIATIONS_SETTING = "workbench.diffEditorAssociations";
+const CHAIN_DIFF_ASSOCIATION_GLOB = "*.chain.qip.yaml";
+
+/**
+ * Keeps `workbench.diffEditorAssociations` in sync with the
+ * `qipExtension.useDefaultDiffView` toggle.
+ *
+ * The extension's `configurationDefaults` map chain file diffs to the visual
+ * editor. When the toggle is on, a user-level `"default"` association
+ * overrides that default so chain diffs open in the built-in text diff; when
+ * the toggle is off, the entry is removed and the default applies again.
+ * Associations for other globs are left untouched.
+ */
+async function syncChainDiffAssociation(): Promise<void> {
+  const useDefaultDiffView = vscode.workspace
+    .getConfiguration("qipExtension")
+    .get<boolean>("useDefaultDiffView", false);
+
+  const configuration = vscode.workspace.getConfiguration();
+  const associations = {
+    ...configuration.inspect<Record<string, string>>(
+      DIFF_EDITOR_ASSOCIATIONS_SETTING,
+    )?.globalValue,
+  };
+
+  if (useDefaultDiffView) {
+    if (associations[CHAIN_DIFF_ASSOCIATION_GLOB] === "default") {
+      return;
+    }
+    associations[CHAIN_DIFF_ASSOCIATION_GLOB] = "default";
+  } else {
+    if (!(CHAIN_DIFF_ASSOCIATION_GLOB in associations)) {
+      return;
+    }
+    delete associations[CHAIN_DIFF_ASSOCIATION_GLOB];
+  }
+
+  await configuration.update(
+    DIFF_EDITOR_ASSOCIATIONS_SETTING,
+    Object.keys(associations).length > 0 ? associations : undefined,
+    vscode.ConfigurationTarget.Global,
+  );
+}
+
 function openWebviewForElement(
   context: ExtensionContext,
   fileUri: Uri,
@@ -802,6 +846,23 @@ export function activate(context: ExtensionContext): QipExtensionAPI {
   context.subscriptions.push(
     vscode.commands.registerCommand("qip.refreshExplorer", () => {
       qipProvider.refresh();
+    }),
+  );
+
+  syncChainDiffAssociation().catch((error) => {
+    console.error("[QIP] Failed to sync chain diff editor association:", error);
+  });
+
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration((e) => {
+      if (e.affectsConfiguration("qipExtension.useDefaultDiffView")) {
+        syncChainDiffAssociation().catch((error) => {
+          console.error(
+            "[QIP] Failed to sync chain diff editor association:",
+            error,
+          );
+        });
+      }
     }),
   );
 

--- a/vscode-extension/tests/extension.test.ts
+++ b/vscode-extension/tests/extension.test.ts
@@ -241,6 +241,145 @@ describe("extension.ts", () => {
     });
   });
 
+  describe("useDefaultDiffView toggle", () => {
+    const DIFF_ASSOCIATIONS_SETTING = "workbench.diffEditorAssociations";
+    const CHAIN_GLOB = "*.chain.qip.yaml";
+
+    const flushAsync = () => new Promise((resolve) => setImmediate(resolve));
+
+    /**
+     * Points the vscode configuration mock at mutable state so tests can flip
+     * the toggle between activation and a configuration-change event.
+     */
+    function configureDiffToggleMocks(state: {
+      useDefaultDiffView: boolean;
+      globalAssociations?: Record<string, string>;
+    }) {
+      const vscode = require("vscode");
+      const update = jest.fn().mockResolvedValue(undefined);
+      vscode.workspace.getConfiguration.mockImplementation(
+        (section?: string) => {
+          if (section === "qipExtension") {
+            return {
+              get: jest.fn((_key: string, defaultVal: any) =>
+                _key === "useDefaultDiffView"
+                  ? state.useDefaultDiffView
+                  : defaultVal,
+              ),
+            };
+          }
+          return {
+            get: jest.fn((_key: string, defaultVal: any) => defaultVal),
+            inspect: jest.fn(() => ({
+              globalValue: state.globalAssociations,
+            })),
+            update,
+          };
+        },
+      );
+      return update;
+    }
+
+    function fireConfigurationChange(affectedSetting: string) {
+      const vscode = require("vscode");
+      const event = {
+        affectsConfiguration: (section: string) => section === affectedSetting,
+      };
+      for (const call of vscode.workspace.onDidChangeConfiguration.mock
+        .calls) {
+        call[0](event);
+      }
+    }
+
+    test("activation writes a 'default' association when the toggle is on", async () => {
+      const update = configureDiffToggleMocks({ useDefaultDiffView: true });
+
+      activate(buildMockContext());
+      await flushAsync();
+
+      expect(update).toHaveBeenCalledWith(
+        DIFF_ASSOCIATIONS_SETTING,
+        { [CHAIN_GLOB]: "default" },
+        require("vscode").ConfigurationTarget.Global,
+      );
+    });
+
+    test("activation removes the association when the toggle is off", async () => {
+      const update = configureDiffToggleMocks({
+        useDefaultDiffView: false,
+        globalAssociations: { [CHAIN_GLOB]: "default" },
+      });
+
+      activate(buildMockContext());
+      await flushAsync();
+
+      expect(update).toHaveBeenCalledWith(
+        DIFF_ASSOCIATIONS_SETTING,
+        undefined,
+        require("vscode").ConfigurationTarget.Global,
+      );
+    });
+
+    test("keeps unrelated associations when removing the chain entry", async () => {
+      const update = configureDiffToggleMocks({
+        useDefaultDiffView: false,
+        globalAssociations: {
+          [CHAIN_GLOB]: "default",
+          "*.md": "vscode.markdown.preview.editor",
+        },
+      });
+
+      activate(buildMockContext());
+      await flushAsync();
+
+      expect(update).toHaveBeenCalledWith(
+        DIFF_ASSOCIATIONS_SETTING,
+        { "*.md": "vscode.markdown.preview.editor" },
+        require("vscode").ConfigurationTarget.Global,
+      );
+    });
+
+    test("does not touch settings when already in sync", async () => {
+      const update = configureDiffToggleMocks({ useDefaultDiffView: false });
+
+      activate(buildMockContext());
+      await flushAsync();
+
+      expect(update).not.toHaveBeenCalled();
+    });
+
+    test("re-syncs when the toggle changes after activation", async () => {
+      const state = { useDefaultDiffView: false };
+      const update = configureDiffToggleMocks(state);
+
+      activate(buildMockContext());
+      await flushAsync();
+      expect(update).not.toHaveBeenCalled();
+
+      state.useDefaultDiffView = true;
+      fireConfigurationChange("qipExtension.useDefaultDiffView");
+      await flushAsync();
+
+      expect(update).toHaveBeenCalledWith(
+        DIFF_ASSOCIATIONS_SETTING,
+        { [CHAIN_GLOB]: "default" },
+        require("vscode").ConfigurationTarget.Global,
+      );
+    });
+
+    test("ignores unrelated configuration changes", async () => {
+      const update = configureDiffToggleMocks({ useDefaultDiffView: false });
+
+      activate(buildMockContext());
+      await flushAsync();
+
+      fireConfigurationChange("editor.fontSize");
+      await flushAsync();
+
+      expect(update).not.toHaveBeenCalled();
+    });
+  });
+
   describe("resolveCustomTextEditorInlineDiff", () => {
     test("registers chain diff handlers and enriches diff webview", async () => {
       const provider = activateAndGetProvider();

--- a/vscode-extension/tests/helpers/mocks.ts
+++ b/vscode-extension/tests/helpers/mocks.ts
@@ -31,6 +31,8 @@ export function createVscodeMock(overrides: Record<string, any> = {}) {
     workspace: {
       getConfiguration: jest.fn().mockReturnValue({
         get: jest.fn((_key: string, defaultVal: any) => defaultVal),
+        inspect: jest.fn(() => undefined),
+        update: jest.fn().mockResolvedValue(undefined),
       }),
       workspaceFolders: [{ uri: { path: "/workspace", fsPath: "/workspace" } }],
       createFileSystemWatcher: jest.fn(() => ({
@@ -52,6 +54,7 @@ export function createVscodeMock(overrides: Record<string, any> = {}) {
       executeCommand: jest.fn(),
     },
     ViewColumn: { One: 1 },
+    ConfigurationTarget: { Global: 1, Workspace: 2, WorkspaceFolder: 3 },
     ColorThemeKind: {
       Light: 1,
       Dark: 2,


### PR DESCRIPTION
closes #524 

key: qipExtension.useDefaultDiffView
default: false
description: Open integration chain diffs in the built-in text diff editor instead of the QIP visual diff. Toggling this updates the `workbench.diffEditorAssociations` entry for `*.chain.qip.yaml` in your user settings.