### PR TITLE
fix: fixed mapping verification

### DIFF
--- a/runtime-catalog/src/main/java/org/qubership/integration/platform/runtime/catalog/mapper/MappingDescriptionValidator.java
+++ b/runtime-catalog/src/main/java/org/qubership/integration/platform/runtime/catalog/mapper/MappingDescriptionValidator.java
@@ -17,15 +17,8 @@
 package org.qubership.integration.platform.runtime.catalog.mapper;
 
 import lombok.extern.slf4j.Slf4j;
-import org.qubership.integration.platform.runtime.catalog.exception.exceptions.SnapshotCreationException;
-import org.qubership.integration.platform.runtime.catalog.model.mapper.datatypes.DataType;
-import org.qubership.integration.platform.runtime.catalog.model.mapper.datatypes.ReferenceType;
 import org.qubership.integration.platform.runtime.catalog.model.mapper.mapping.MappingDescription;
-import org.qubership.integration.platform.runtime.catalog.model.mapper.mapping.definition.Attribute;
 import org.springframework.stereotype.Service;
-
-import java.util.*;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -39,113 +32,8 @@ public class MappingDescriptionValidator {
         validateMandatoryFields(mappingDescription);
     }
 
-    /**
-     * Validation that all fields which marked as required ({@link Attribute#required required }) in output ({@link MappingDescription#target target}) model
-     * participate in mapping ({@link MappingDescription#actions actions})
-     *
-     * @param mappingDescription input mapping description
-     * @throws SnapshotCreationException when one or move required fields are not mapped
-     */
     private void validateMandatoryFields(MappingDescription mappingDescription) {
-        //Collect all mandatoryAttributes with path
-        Map<Integer, LinkedList<String>> pathsToMandatoryAttributes = new HashMap<>();
-
-        //Headers
-        pathsToMandatoryAttributes.putAll(getMandatoryHeaders(mappingDescription));
-
-        //Properties
-        pathsToMandatoryAttributes.putAll(getMandatoryProperties(mappingDescription));
-
-        //Target body
-        pathsToMandatoryAttributes.putAll(getMandatoryBody(mappingDescription));
-
-        if (!pathsToMandatoryAttributes.isEmpty() && mappingDescription.getActions().isEmpty()) {
-            throw new SnapshotCreationException(NO_MAPPING_FOR_REQUIRED_ATTRIBUTES_ERROR_MESSAGE);
-        }
-
-        if (!pathsToMandatoryAttributes.isEmpty()) {
-            //Collect all mapping relation path
-            List<List<String>> targetPaths = mappingDescription
-                    .getActions()
-                    .stream()
-                    .map(mappingAction -> mappingAction.getTarget().getPath())
-                    .toList();
-
-            //Check mandatory paths in existing mappings
-            List<Integer> missingMandatoryAttributes = pathsToMandatoryAttributes
-                    .keySet()
-                    .stream()
-                    .filter(attrId -> {
-                        List<String> attrPaths = pathsToMandatoryAttributes.get(attrId);
-                        return targetPaths
-                                .stream()
-                                .noneMatch(targetPath -> Arrays.equals(targetPath.toArray(), attrPaths.toArray()));
-                    })
-                    .toList();
-
-            if (!missingMandatoryAttributes.isEmpty()) {
-                throw new SnapshotCreationException(MANDATORY_FIELDS_MISSING_IN_MAPPING_ERROR_MESSAGE);
-            }
-        }
+        // Since changing a field's data type or its 'Required' flag during a schema update must not break the mapping,
+        // we cannot validate that mandatory attributes are mapped anymore.
     }
-
-    private Map<Integer, LinkedList<String>> getMandatoryHeaders(MappingDescription mappingDescription) {
-        return mappingDescription
-                .getTarget()
-                .getHeaders()
-                .stream()
-                .filter(Attribute::getRequired)
-                .map(Attribute::getId)
-                .collect(Collectors.toMap(String::hashCode, attribute -> new LinkedList<>()));
-    }
-
-    private Map<Integer, LinkedList<String>> getMandatoryProperties(MappingDescription mappingDescription) {
-        Collection<Attribute> targetProperties = mappingDescription.getTarget().getProperties();
-        Map<Integer, LinkedList<String>> pathsToMandatoryProperties = new HashMap<>();
-
-        collectMandatoryAttributes(targetProperties, pathsToMandatoryProperties, new LinkedList<>(), new HashMap<>());
-
-        return pathsToMandatoryProperties;
-    }
-
-    private Map<Integer, LinkedList<String>> getMandatoryBody(MappingDescription mappingDescription) {
-        Collection<Attribute> targetAttributes = mappingDescription.getTarget().getBody().getNestedAttributes();
-        Map<Integer, LinkedList<String>> pathToMandatoryAttributes = new HashMap<>();
-
-        collectMandatoryAttributes(targetAttributes, pathToMandatoryAttributes, new LinkedList<>(), mappingDescription.getTarget().getBodyDefinitions());
-
-        return pathToMandatoryAttributes;
-
-    }
-
-    private void collectMandatoryAttributes(Collection<Attribute> allAttributes,
-                                            Map<Integer, LinkedList<String>> mandatoryAttributes,
-                                            LinkedList<String> currentPath,
-                                            Map<String, DataType> attributeDefinitions) {
-        boolean mandatoryAttributeFound;
-        for (Attribute attribute : allAttributes) {
-            DataType resolvedDataType = null;
-            mandatoryAttributeFound = attribute.getRequired();
-
-            if (attribute.getType() instanceof ReferenceType attributeReferenceType) {
-                resolvedDataType = attributeDefinitions.getOrDefault(attributeReferenceType.getDefinitionId(), null);
-            }
-
-            Collection<Attribute> nestedAttributes = resolvedDataType != null ? resolvedDataType.getNestedAttributes() : attribute.getType().getNestedAttributes();
-
-            if (!nestedAttributes.isEmpty()) {
-                mandatoryAttributeFound = false;
-                currentPath.add(attribute.getId());
-                collectMandatoryAttributes(nestedAttributes, mandatoryAttributes, currentPath, attributeDefinitions);
-
-            }
-
-            if (mandatoryAttributeFound) {
-                currentPath.add(attribute.getId());
-                mandatoryAttributes.put(currentPath.hashCode(), new LinkedList<>(currentPath));
-                currentPath.clear();
-            }
-        }
-    }
-
 }


### PR DESCRIPTION
closes #525 

Since changing a field's data type or its 'Required' flag during a schema update must not break the mapping, we cannot validate that mandatory attributes are mapped anymore.