### PR TITLE
fix: fixed MCP trigger parameters

### DIFF
--- a/engine/src/main/java/org/qubership/integration/platform/engine/service/deployment/processing/actions/context/create/McpToolRegistrar.java
+++ b/engine/src/main/java/org/qubership/integration/platform/engine/service/deployment/processing/actions/context/create/McpToolRegistrar.java
@@ -87,7 +87,7 @@ public class McpToolRegistrar extends ElementProcessingAction {
                         Boolean.valueOf(props.get("destructive")),
                         Boolean.valueOf(props.get("idempotent")),
                         Boolean.valueOf(props.get("openWorld")),
-                        Boolean.valueOf(props.get("requiresLocal"))))
+                        false))
                 .meta(Map.of(DEPLOYMENT_ID, deploymentInfo.getDeploymentId()))
                 .inputSchema(mcpJsonMapper, props.get("inputSchema"));
         String outputSchema = props.get("outputSchema");

--- a/engine/src/test/java/org/qubership/integration/platform/engine/service/deployment/processing/actions/context/create/McpToolRegistrarTest.java
+++ b/engine/src/test/java/org/qubership/integration/platform/engine/service/deployment/processing/actions/context/create/McpToolRegistrarTest.java
@@ -166,7 +166,6 @@ class McpToolRegistrarTest {
         props.put("destructive", "false");
         props.put("idempotent", "true");
         props.put("openWorld", "false");
-        props.put("requiresLocal", "false");
         props.put("inputSchema", INPUT_SCHEMA);
         if (outputSchema != null) {
             props.put("outputSchema", outputSchema);

--- a/runtime-catalog/src/main/java/org/qubership/integration/platform/runtime/catalog/cr/sources/builders/xml/beans/builders/element/McpTriggerBeansBuilder.java
+++ b/runtime-catalog/src/main/java/org/qubership/integration/platform/runtime/catalog/cr/sources/builders/xml/beans/builders/element/McpTriggerBeansBuilder.java
@@ -38,8 +38,7 @@ public class McpTriggerBeansBuilder implements ElementBeansBuilder {
                 "readOnly",
                 "destructive",
                 "idempotent",
-                "openWorld",
-                "requiresLocal"
+                "openWorld"
         );
 
         for (String propertyName : propertyNames) {

--- a/runtime-catalog/src/main/java/org/qubership/integration/platform/runtime/catalog/service/deployment/properties/builders/McpTriggerPropertiesBuilder.java
+++ b/runtime-catalog/src/main/java/org/qubership/integration/platform/runtime/catalog/service/deployment/properties/builders/McpTriggerPropertiesBuilder.java
@@ -32,8 +32,7 @@ public class McpTriggerPropertiesBuilder implements ElementPropertiesBuilder {
                 "readOnly",
                 "destructive",
                 "idempotent",
-                "openWorld",
-                "requiresLocal"
+                "openWorld"
         ).collect(Collectors.toMap(
                 Function.identity(),
                 key -> Optional.ofNullable(element.getProperties().get(key))

--- a/runtime-catalog/src/main/resources/elements/mcp-trigger/description.yml
+++ b/runtime-catalog/src/main/resources/elements/mcp-trigger/description.yml
@@ -71,8 +71,3 @@ properties:
       default: false
       title: Tool may interact with external entities beyond its local environment
       description: Defines if the tool interacts with an unpredictable external environment (like a web search) or a closed, well-defined system.
-    - name: requiresLocal
-      type: boolean
-      default: false
-      title: Tool needs local resources or execution
-      description: A specialized hint (common in Azure MCP) indicating the tool needs local resources or execution.

--- a/runtime-catalog/src/test/java/org/qubership/integration/platform/runtime/catalog/service/deployment/properties/builders/McpTriggerPropertiesBuilderTest.java
+++ b/runtime-catalog/src/test/java/org/qubership/integration/platform/runtime/catalog/service/deployment/properties/builders/McpTriggerPropertiesBuilderTest.java
@@ -72,7 +72,7 @@ class McpTriggerPropertiesBuilderTest {
         assertThat(result.keySet(), containsInAnyOrder(
                 "mcpServiceIds", "name", "title", "description",
                 "inputSchema", "outputSchema", "readOnly", "destructive",
-                "idempotent", "openWorld", "requiresLocal"
+                "idempotent", "openWorld"
         ));
     }
 
@@ -90,7 +90,6 @@ class McpTriggerPropertiesBuilderTest {
         properties.put("destructive", false);
         properties.put("idempotent", true);
         properties.put("openWorld", false);
-        properties.put("requiresLocal", true);
 
         ChainElement element = ChainElement.builder()
                 .type("mcp-trigger")
@@ -109,8 +108,7 @@ class McpTriggerPropertiesBuilderTest {
                 hasEntry("readOnly", "true"),
                 hasEntry("destructive", "false"),
                 hasEntry("idempotent", "true"),
-                hasEntry("openWorld", "false"),
-                hasEntry("requiresLocal", "true")
+                hasEntry("openWorld", "false")
         ));
     }
 
@@ -157,12 +155,12 @@ class McpTriggerPropertiesBuilderTest {
     }
 
     @Test
-    @DisplayName("build returns exactly 11 entries")
-    void buildReturnsExactly11Entries() {
+    @DisplayName("build returns exactly 10 entries")
+    void buildReturnsExactly10Entries() {
         ChainElement element = ChainElement.builder().type("mcp-trigger").build();
 
         Map<String, String> result = builder.build(element);
 
-        assertThat(result.size(), equalTo(11));
+        assertThat(result.size(), equalTo(10));
     }
 }

--- a/vscode-extension/media/library.json
+++ b/vscode-extension/media/library.json
@@ -5853,23 +5853,6 @@
                 "multiple": false,
                 "reference": false,
                 "default": "false"
-              },
-              {
-                "name": "requiresLocal",
-                "title": "Tool needs local resources or execution",
-                "description": "A specialized hint (common in Azure MCP) indicating the tool needs local resources or execution.",
-                "type": "boolean",
-                "resetValueOnCopy": false,
-                "unique": false,
-                "caseInsensitive": false,
-                "mandatory": false,
-                "autofocus": false,
-                "query": false,
-                "allowedValues": [],
-                "allowCustomValue": true,
-                "multiple": false,
-                "reference": false,
-                "default": "false"
               }
             ],
             "advanced": [],


### PR DESCRIPTION
closes #516 

The requiresLocal annotation is Microsoft proprietary annotation and not a part of MCP spec. This annotation supported by Spring, and not supported by Quarkus. Therefore, it should be removed from MCP Trigger parameters list.