### PR TITLE
fix: remove description field from folder create/edit form

### DIFF
--- a/ui/src/components/modal/FolderEdit.tsx
+++ b/ui/src/components/modal/FolderEdit.tsx
@@ -4,8 +4,6 @@ import { useModalContext } from "../../ModalContextProvider.tsx";
 import type { FieldData } from "../../types/antd.ts";
 import { GROUP_SEGMENT_REGEX } from "../../misc/group-utils.ts";
 
-const { TextArea } = Input;
-
 export type FolderEditMode = "create" | "update";
 
 export type FolderEditProps = {
@@ -121,9 +119,6 @@ export const FolderEdit: React.FC<FolderEditProps> = ({
           ]}
         >
           <Input ref={nameInput} />
-        </Form.Item>
-        <Form.Item name="description" label="Description">
-          <TextArea className="fixed-textarea" />
         </Form.Item>
         {mode === "create" ? (
           <Flex vertical={false} style={{ marginLeft: 150 }}>

--- a/ui/tests/components/modal/FolderEdit.test.tsx
+++ b/ui/tests/components/modal/FolderEdit.test.tsx
@@ -47,6 +47,15 @@ describe("FolderEdit", () => {
     ).toBeInTheDocument();
   });
 
+  it.each(["create", "update"] as const)(
+    "should not render a description field when mode is %s",
+    (mode) => {
+      render(<FolderEdit onSubmit={jest.fn()} mode={mode} />);
+      expect(screen.queryByText("Description")).not.toBeInTheDocument();
+      expect(screen.getAllByRole("textbox")).toHaveLength(1);
+    },
+  );
+
   it("should submit name from initial values and fields", async () => {
     const onSubmit = jest.fn();
     render(<FolderEdit onSubmit={onSubmit} mode="update" name="N0" />);


### PR DESCRIPTION
Folders became plain segments of a chain's `metaInfo.group` path, so they no longer carry their own description: the field was dropped from the form in "feat: group instead of folders" but came back through the antd v6 merge. It rendered a textarea whose value was never read or submitted.

Closes #527